### PR TITLE
Local Nginx server with prod conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ yarn-error.log*
 
 # Misc infra scripts
 devops
+
+# Local nginx
+nginx/

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Ce `README` s'adresse aux développeurs informatiques du projet. Pour plus d'inf
 Le projet est divisé en 2 grandes briques distinctes :
 
 - le front (= le site web Mobilic)
+
   - Single Page App React.js servie par Nginx (statique)
   - le dépôt est organisé par outil
 
@@ -25,6 +26,7 @@ Le projet est divisé en 2 grandes briques distinctes :
     - `web/control` : divers services pour les corps de contrôle
     - `web/landing` : pages publiques
     - `web/home` : homepage d'un utilisateur
+
 - le back (l'API Mobilic)
   - Application Flask servie par Gunicorn avec une API GraphQL
   - [lien vers le dépôt](https://github.com/MTES-MCT/mobilic-api)
@@ -108,7 +110,7 @@ L'intérêt d'utiliser une image de production plutôt que le serveur de dévelo
 - soit pour évaluer la performance du code
 - soit pour tester le mode offline de la PWA (en effet le serveur de développement ne permet pas de configurer le service worker du navigateur).
 
-### Tester la config Nginx
+### Tester dans des conditions identiques à la production
 
 En production l'image générée par `yarn build` est servie par un serveur nginx qui effectue en plus les choses suivantes :
 
@@ -116,7 +118,13 @@ En production l'image générée par `yarn build` est servie par un serveur ngin
 - ajoute les en-tête de réponse, notamment concernant la gestion de cache et la sécurité
 - reverse proxy les requêtes à `/api` vers le serveur du back
 
-Cette couche Nginx est ajoutée via un [buildpack Scalingo](https://doc.scalingo.com/platform/deployment/buildpacks/nginx), qui construit un ficher de config nginx valide à partir des [données suivantes](./servers.conf.erb). Le template utilisé par Scalingo pour le fichier est [ici](https://github.com/Scalingo/nginx-buildpack/blob/master/config/nginx.conf.erb).
+Cette couche Nginx est ajoutée via un [buildpack Scalingo](https://doc.scalingo.com/platform/deployment/buildpacks/nginx), qui construit un ficher de config nginx valide à partir des [données suivantes](./servers.conf.erb).
+
+En développement local il est possible d'ajouter cette couche Nginx (avec la même configuration sauf la partie https). La commande suivante permet de créer une image de production puis de la servir via un serveur Nginx :
+
+```sh
+REACT_APP_API_HOST=... yarn build-with-nginx
+```
 
 ## Infos complémentaires
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,11 @@ En développement local il est possible d'ajouter cette couche Nginx (avec la m�
 REACT_APP_API_HOST=... yarn build-with-nginx
 ```
 
+Cette commande nécessite comme pré-requis :
+
+- `nginx` en ligne de commande
+- `erb`, la ligne de commande de Ruby pour remplir des templates
+
 ## Infos complémentaires
 
 Le front a été initialisé avec la boîte à outils [Create React App](https://github.com/facebook/create-react-app).

--- a/nginx/base_conf/base_conf.erb
+++ b/nginx/base_conf/base_conf.erb
@@ -1,0 +1,68 @@
+worker_processes auto;
+daemon off;
+
+events {
+    worker_connections  1024;
+}
+http {
+    # Hide nginx version information.
+    server_tokens off;
+
+    sendfile    on;
+    tcp_nopush  on;
+    tcp_nodelay off;
+
+    keepalive_timeout  65;
+
+    log_format specialLog '$http_x_forwarded_for - '
+                      '"$request" $status $body_bytes_sent $request_time '
+                      '"$http_referer" "$http_user_agent"';
+
+    error_log logs/error.log notice;
+    access_log logs/access.log specialLog;
+
+    client_max_body_size 100m;
+    client_body_timeout 600s;
+
+    upstream php {
+        server unix:/tmp/php-fpm.sock max_fails=3 fail_timeout=3s;
+        keepalive 16;
+    }
+
+    index index.html index.htm index.xhtml;
+    include mime.types;
+    default_type application/octet-stream;
+
+    set_real_ip_from 0.0.0.0/0;
+    real_ip_header X-Forwarded-For;
+
+    root <%= ENV['HOME'] %>;
+
+    # Enable Gzip compression.
+    gzip on;
+    gzip_http_version 1.0;
+    gzip_comp_level 5;
+    gzip_min_length 256;
+    gzip_proxied any;
+    gzip_vary on;
+    gzip_types
+      application/atom+xml
+      application/javascript
+      application/x-javascript
+      application/json
+      application/rss+xml
+      application/vnd.ms-fontobject
+      application/x-font-ttf
+      application/x-web-app-manifest+json
+      application/xhtml+xml
+      application/xml
+      font/opentype
+      image/svg+xml
+      image/x-icon
+      text/css
+      text/plain
+      text/x-component;
+    # text/html is always compressed by HttpGzipModule
+
+    include servers.conf;
+}

--- a/nginx/base_conf/mime.types
+++ b/nginx/base_conf/mime.types
@@ -1,0 +1,97 @@
+types {
+    text/html                                        html htm shtml;
+    text/css                                         css;
+    text/xml                                         xml;
+    image/gif                                        gif;
+    image/jpeg                                       jpeg jpg;
+    application/javascript                           js;
+    application/atom+xml                             atom;
+    application/rss+xml                              rss;
+
+    text/mathml                                      mml;
+    text/plain                                       txt;
+    text/vnd.sun.j2me.app-descriptor                 jad;
+    text/vnd.wap.wml                                 wml;
+    text/x-component                                 htc;
+
+    image/png                                        png;
+    image/svg+xml                                    svg svgz;
+    image/tiff                                       tif tiff;
+    image/vnd.wap.wbmp                               wbmp;
+    image/webp                                       webp;
+    image/x-icon                                     ico;
+    image/x-jng                                      jng;
+    image/x-ms-bmp                                   bmp;
+
+    font/woff                                        woff;
+    font/woff2                                       woff2;
+
+    application/java-archive                         jar war ear;
+    application/json                                 json;
+    application/mac-binhex40                         hqx;
+    application/msword                               doc;
+    application/pdf                                  pdf;
+    application/postscript                           ps eps ai;
+    application/rtf                                  rtf;
+    application/vnd.apple.mpegurl                    m3u8;
+    application/vnd.google-earth.kml+xml             kml;
+    application/vnd.google-earth.kmz                 kmz;
+    application/vnd.ms-excel                         xls;
+    application/vnd.ms-fontobject                    eot;
+    application/vnd.ms-powerpoint                    ppt;
+    application/vnd.oasis.opendocument.graphics      odg;
+    application/vnd.oasis.opendocument.presentation  odp;
+    application/vnd.oasis.opendocument.spreadsheet   ods;
+    application/vnd.oasis.opendocument.text          odt;
+    application/vnd.openxmlformats-officedocument.presentationml.presentation
+                                                     pptx;
+    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+                                                     xlsx;
+    application/vnd.openxmlformats-officedocument.wordprocessingml.document
+                                                     docx;
+    application/vnd.wap.wmlc                         wmlc;
+    application/wasm                                 wasm;
+    application/x-7z-compressed                      7z;
+    application/x-cocoa                              cco;
+    application/x-java-archive-diff                  jardiff;
+    application/x-java-jnlp-file                     jnlp;
+    application/x-makeself                           run;
+    application/x-perl                               pl pm;
+    application/x-pilot                              prc pdb;
+    application/x-rar-compressed                     rar;
+    application/x-redhat-package-manager             rpm;
+    application/x-sea                                sea;
+    application/x-shockwave-flash                    swf;
+    application/x-stuffit                            sit;
+    application/x-tcl                                tcl tk;
+    application/x-x509-ca-cert                       der pem crt;
+    application/x-xpinstall                          xpi;
+    application/xhtml+xml                            xhtml;
+    application/xspf+xml                             xspf;
+    application/zip                                  zip;
+
+    application/octet-stream                         bin exe dll;
+    application/octet-stream                         deb;
+    application/octet-stream                         dmg;
+    application/octet-stream                         iso img;
+    application/octet-stream                         msi msp msm;
+
+    audio/midi                                       mid midi kar;
+    audio/mpeg                                       mp3;
+    audio/ogg                                        ogg;
+    audio/x-m4a                                      m4a;
+    audio/x-realaudio                                ra;
+
+    video/3gpp                                       3gpp 3gp;
+    video/mp2t                                       ts;
+    video/mp4                                        mp4;
+    video/mpeg                                       mpeg mpg;
+    video/quicktime                                  mov;
+    video/webm                                       webm;
+    video/x-flv                                      flv;
+    video/x-m4v                                      m4v;
+    video/x-mng                                      mng;
+    video/x-ms-asf                                   asx asf;
+    video/x-ms-wmv                                   wmv;
+    video/x-msvideo                                  avi;
+}

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "start": "node scripts/start.js",
     "start-https": "HTTPS=true node scripts/start.js",
     "build": "INLINE_RUNTIME_CHUNK=false node scripts/build.js && rm build/static/js/*.map && yarn build-doc && yarn inject-doc-build",
+    "build-with-nginx": "yarn build && scripts/start_nginx.sh",
     "build-doc": "cd docs/website && yarn install && yarn build && cd ../..",
     "inject-doc-build": "rm -rf build/developers && cp -r docs/website/build/api-mobilic-doc build/developers",
     "test": "node scripts/test.js",

--- a/scripts/start_nginx.sh
+++ b/scripts/start_nginx.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -e
+
+ROOT_PROJECT_DIR=`dirname "$(python -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"`/..
+cd ${ROOT_PROJECT_DIR}
+
+export API_HOST=${REACT_APP_API_HOST}
+export PORT=3001
+export HOME=nginx
+export BUILD_FOLDER=${ROOT_PROJECT_DIR}/build
+export DISABLE_FORCE_HTTPS=1
+
+mkdir -p nginx/conf
+mkdir -p nginx/logs
+
+erb nginx/base_conf/base_conf.erb > nginx/conf/nginx.conf
+cp nginx/base_conf/mime.types nginx/conf/mime.types
+erb servers.conf.erb > nginx/conf/servers.conf
+
+nginx -p ${ROOT_PROJECT_DIR}/nginx -c ${ROOT_PROJECT_DIR}/nginx/conf/nginx.conf

--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -13,11 +13,13 @@ server {
 
     port_in_redirect off;
     keepalive_timeout 5;
-    root /app/build/;
+    root <%= ENV['BUILD_FOLDER'] || "/app/build/" %>;
 
-    if ($http_x_forwarded_proto != "https") {
-      return 301 https://$host$request_uri;
-    }
+    <% if not ENV['DISABLE_FORCE_HTTPS'] %>
+        if ($http_x_forwarded_proto != "https") {
+          return 301 https://$host$request_uri;
+        }
+    <% end %>
 
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
     add_header X-Frame-Options "deny";


### PR DESCRIPTION
Permet de faire tourner le front end en local dans les mêmes conditions qu'en prod, c'est-à-dire avec un serveur Nginx qui va notamment permettre de proxy les requêtes `/api` vers le bon backend.

Pour réaliser ça j'ai plus ou moins copié ce que faisait le [buildpack Scalingo](https://github.com/Scalingo/nginx-buildpack).

* Le fichier `nginx/base_conf/base_conf.erb` est une copie de leur template de config (https://github.com/Scalingo/nginx-buildpack/blob/master/config/nginx.conf.erb)

* Le script `scripts/start_nginx.sh` génère des fichiers de config à partir des templates (`nginx/base_conf/base_conf.erb` et `servers.conf.erb`) et des variablesrequises (REACT_APP_API_HOST, PORT, ...), puis lance un serveur nginx à partir de cette config.

* Une nouvelle commande `yarn build-with-nginx` permet de faire tourner le front-end en conditions de prod (`yarn build` + `scripts/start_nginx.sh`)

⚠️ Le process détaillé ci-dessus ne marche pas lorsque le nom de domaine de `REACT_APP_API_HOST` est `localhost` (erreur Nginx : https://talk.plesk.com/threads/nginx-localhost-cant-be-resolved.355911/). Pour pallier à ça on peut utiliser `127.0.0.1` ou l'IP sur le réseau local.