### PR TITLE
Enh/disable refresh token

### DIFF
--- a/web/control/UserRead.js
+++ b/web/control/UserRead.js
@@ -72,7 +72,8 @@ export function UserRead() {
               {
                 token
               },
-              { context: { nonPublicApi: true } }
+              { context: { nonPublicApi: true } },
+              true
             );
             const userPayload = userResponse.data.userFromReadToken.user;
             setTokenInfo({

--- a/web/control/VerifyXlsxSignature.js
+++ b/web/control/VerifyXlsxSignature.js
@@ -156,7 +156,8 @@ export function XlsxVerifier() {
           {
             body: fd,
             timeout: 15000
-          }
+          },
+          true
         );
         const json = await apiResponse.json();
         setVerifyResponse(json);

--- a/web/landing/ResetPassword.js
+++ b/web/landing/ResetPassword.js
@@ -87,7 +87,8 @@ export function ResetPassword() {
           { token, password },
           {
             context: { nonPublicApi: true }
-          }
+          },
+          true
         );
         await store.updateUserIdAndInfo();
         setDidSubmitForm(true);
@@ -228,7 +229,8 @@ export function RequestResetPassword() {
         { mail: email },
         {
           context: { nonPublicApi: true }
-        }
+        },
+        true
       );
       if (!apiResponse.data.account.requestResetPassword.success) {
         throw Error;

--- a/web/landing/login.js
+++ b/web/landing/login.js
@@ -43,10 +43,15 @@ export default function Login() {
     setLoading(true);
     await alerts.withApiErrorHandling(
       async () => {
-        await api.graphQlMutate(LOGIN_MUTATION, {
-          email,
-          password
-        });
+        await api.graphQlMutate(
+          LOGIN_MUTATION,
+          {
+            email,
+            password
+          },
+          {},
+          true
+        );
         await store.updateUserIdAndInfo();
       },
       "login",

--- a/web/landing/signup/AccountCreation.js
+++ b/web/landing/signup/AccountCreation.js
@@ -90,9 +90,14 @@ export function AccountCreation({ employeeInvite, isAdmin }) {
         if (employeeInvite) {
           signupPayload.inviteToken = employeeInvite.inviteToken;
         }
-        await api.graphQlMutate(USER_SIGNUP_MUTATION, signupPayload, {
-          context: { nonPublicApi: true }
-        });
+        await api.graphQlMutate(
+          USER_SIGNUP_MUTATION,
+          signupPayload,
+          {
+            context: { nonPublicApi: true }
+          },
+          true
+        );
         await store.updateUserIdAndInfo();
         if (isAdmin) history.push("/signup/company?onboarding=true");
         else history.push("/signup/complete");

--- a/web/landing/signup/FranceConnectCallback.js
+++ b/web/landing/signup/FranceConnectCallback.js
@@ -44,7 +44,8 @@ export function FranceConnectCallback() {
             create: !!create,
             state
           },
-          { context: { nonPublicApi: true } }
+          { context: { nonPublicApi: true } },
+          true
         );
         await store.updateUserIdAndInfo();
         if (create) history.push("/signup/user_login");


### PR DESCRIPTION
Aujourd'hui on vérifie avant chaque requête à l'API l'expiration du jeton d'accès et on refreshe éventuellement, même pour les requêtes :

* qui n'utilisent pas le token

* et/ou qui vont de toute manière retourner de nouveaux tokens (login, logout, ...)

Cette PR change ça pour ne refresh que lorsque c'est vraiment nécessaire