### PR TITLE
Add/newsletter subscription

### DIFF
--- a/common/utils/apiQueries.js
+++ b/common/utils/apiQueries.js
@@ -97,6 +97,7 @@ export const USER_SIGNUP_MUTATION = gql`
     $firstName: String!
     $lastName: String!
     $inviteToken: String
+    $subscribeToNewsletter: Boolean
   ) {
     signUp {
       user(
@@ -105,6 +106,7 @@ export const USER_SIGNUP_MUTATION = gql`
         firstName: $firstName
         lastName: $lastName
         inviteToken: $inviteToken
+        subscribeToNewsletter: $subscribeToNewsletter
       ) {
         accessToken
         refreshToken

--- a/common/utils/apiQueries.js
+++ b/common/utils/apiQueries.js
@@ -1114,3 +1114,46 @@ export function buildLogLocationPayloadFromAddress(
 
   return payload;
 }
+
+export const HTTP_QUERIES = {
+  subscribeToNewsletter: {
+    method: "POST",
+    endpoint: "/contacts/subscribe-to-newsletter"
+  },
+  verifyXlsxSignature: {
+    method: "POST",
+    endpoint: "/control/verify-xlsx-signature"
+  },
+  generateUserReadToken: {
+    method: "POST",
+    endpoint: "/control/generate-user-read-token"
+  },
+  refresh: {
+    method: "POST",
+    endpoint: "/token/refresh"
+  },
+  logout: {
+    method: "POST",
+    endpoint: "/token/logout"
+  },
+  excelExport: {
+    method: "POST",
+    endpoint: "/companies/download_activity_report"
+  },
+  userC1bExport: {
+    method: "POST",
+    endpoint: "/users/generate_tachograph_file"
+  },
+  companyC1bExport: {
+    method: "POST",
+    endpoint: "/companies/generate_tachograph_files"
+  },
+  pdfExport: {
+    method: "POST",
+    endpoint: "/users/generate_pdf_export"
+  },
+  oauthAuthorize: {
+    method: "GET",
+    endpoint: "/oauth/authorize"
+  }
+};

--- a/common/utils/validation.js
+++ b/common/utils/validation.js
@@ -1,0 +1,9 @@
+const VALID_EMAIL_RE = /^[a-z0-9._+-]+[@][a-z0-9-]+(\.[a-z0-9-]+)+$/;
+
+export function validateCleanEmailString(cleanString) {
+  return VALID_EMAIL_RE.test(cleanString);
+}
+
+export function cleanEmailString(string) {
+  return string.toLowerCase().replace(/\s/g, "");
+}

--- a/web/admin/components/C1BExport.js
+++ b/web/admin/components/C1BExport.js
@@ -20,6 +20,7 @@ import Box from "@material-ui/core/Box";
 import Switch from "@material-ui/core/Switch/Switch";
 import { DAY, isoFormatLocalDate } from "common/utils/time";
 import Alert from "@material-ui/lab/Alert";
+import { HTTP_QUERIES } from "common/utils/apiQueries";
 
 const useStyles = makeStyles(theme => ({
   start: {
@@ -237,11 +238,9 @@ export default function C1BExport({
               linkType: "download"
             });
             try {
-              await api.downloadFileHttpQuery(
-                "POST",
-                `/companies/generate_tachograph_files`,
-                { json: options }
-              );
+              await api.downloadFileHttpQuery(HTTP_QUERIES.companyC1bExport, {
+                json: options
+              });
             } catch (err) {
               alerts.error(
                 formatApiError(err),

--- a/web/admin/components/ExcelExport.js
+++ b/web/admin/components/ExcelExport.js
@@ -16,6 +16,7 @@ import { EmployeeFilter } from "./EmployeeFilter";
 import { useMatomo } from "@datapunt/matomo-tracker-react";
 import Grid from "@material-ui/core/Grid";
 import { isoFormatLocalDate } from "common/utils/time";
+import { HTTP_QUERIES } from "common/utils/apiQueries";
 
 const useStyles = makeStyles(theme => ({
   start: {
@@ -179,11 +180,9 @@ export default function ExcelExport({
                 href: `/download_company_activity_report`,
                 linkType: "download"
               });
-              await api.downloadFileHttpQuery(
-                "POST",
-                `/companies/download_activity_report`,
-                { json: options }
-              );
+              await api.downloadFileHttpQuery(HTTP_QUERIES.excelExport, {
+                json: options
+              });
             }, "download-company-report")
           }
         >

--- a/web/common/CheckboxField.js
+++ b/web/common/CheckboxField.js
@@ -1,0 +1,40 @@
+import React from "react";
+import FormGroup from "@material-ui/core/FormGroup/FormGroup";
+import FormControlLabel from "@material-ui/core/FormControlLabel/FormControlLabel";
+import Checkbox from "@material-ui/core/Checkbox/Checkbox";
+import makeStyles from "@material-ui/core/styles/makeStyles";
+
+const useStyles = makeStyles(theme => ({
+  container: {
+    marginTop: theme.spacing(2),
+    marginBottom: theme.spacing(2)
+  },
+  inner: {
+    alignItems: "flex-start",
+    textAlign: "left"
+  },
+  checkbox: {
+    paddingTop: 0
+  }
+}));
+
+export function CheckboxField({ checked, required, onChange, label }) {
+  const classes = useStyles();
+  return (
+    <FormGroup className={classes.container}>
+      <FormControlLabel
+        className={classes.inner}
+        control={
+          <Checkbox
+            required={required}
+            color="primary"
+            className={classes.checkbox}
+            checked={checked}
+            onChange={onChange}
+          />
+        }
+        label={label}
+      />
+    </FormGroup>
+  );
+}

--- a/web/common/EmailField.js
+++ b/web/common/EmailField.js
@@ -16,16 +16,19 @@ export function EmailField({
   React.useEffect(() => {
     if (validate && value && value !== "" && !validateCleanEmailString(value)) {
       setError("Le format de l'adresse n'est pas valide");
-    } else if (error && setError) setError(null);
+    } else if (error && setError) setError("");
   }, [value]);
+
+  const [actualInput, setActualInput] = React.useState(value);
 
   return (
     <TextField
       type="email"
-      value={value}
+      value={actualInput}
       onChange={e => {
         const newValue = e.target.value;
         const cleanValue = newValue ? cleanEmailString(newValue) : newValue;
+        setActualInput(newValue);
         setValue(cleanValue);
       }}
       error={!!error}

--- a/web/common/EmailField.js
+++ b/web/common/EmailField.js
@@ -1,0 +1,36 @@
+import TextField from "@material-ui/core/TextField/TextField";
+import React from "react";
+import {
+  cleanEmailString,
+  validateCleanEmailString
+} from "common/utils/validation";
+
+export function EmailField({
+  value,
+  setValue,
+  error,
+  setError,
+  validate,
+  ...props
+}) {
+  React.useEffect(() => {
+    if (validate && value && value !== "" && !validateCleanEmailString(value)) {
+      setError("Le format de l'adresse n'est pas valide");
+    } else if (error && setError) setError(null);
+  }, [value]);
+
+  return (
+    <TextField
+      type="email"
+      value={value}
+      onChange={e => {
+        const newValue = e.target.value;
+        const cleanValue = newValue ? cleanEmailString(newValue) : newValue;
+        setValue(cleanValue);
+      }}
+      error={!!error}
+      helperText={error}
+      {...props}
+    />
+  );
+}

--- a/web/control/UserRead.js
+++ b/web/control/UserRead.js
@@ -22,7 +22,7 @@ import { formatApiError, graphQLErrorMatchesCode } from "common/utils/errors";
 import { History } from "../pwa/screens/History";
 import Grid from "@material-ui/core/Grid";
 import { InfoItem } from "../home/InfoField";
-import { USER_READ_QUERY } from "common/utils/apiQueries";
+import { HTTP_QUERIES, USER_READ_QUERY } from "common/utils/apiQueries";
 import { LoadingButton } from "common/components/LoadingButton";
 import { useSnackbarAlerts } from "../common/Snackbar";
 import * as Sentry from "@sentry/browser";
@@ -230,8 +230,7 @@ export function UserRead() {
                   onClick={async () => {
                     try {
                       await api.downloadFileHttpQuery(
-                        "POST",
-                        `/users/generate_tachograph_file`,
+                        HTTP_QUERIES.userC1bExport,
                         { json: { token: tokenInfo.token } }
                       );
                     } catch (err) {

--- a/web/control/UserReadQRCode.js
+++ b/web/control/UserReadQRCode.js
@@ -9,6 +9,7 @@ import { useApi } from "common/utils/api";
 import { formatApiError } from "common/utils/errors";
 import makeStyles from "@material-ui/core/styles/makeStyles";
 import { now } from "common/utils/time";
+import { HTTP_QUERIES } from "common/utils/apiQueries";
 
 const useStyles = makeStyles(theme => ({
   container: {
@@ -40,8 +41,7 @@ export default function UserReadQRCodeModal({ open, handleClose }) {
   async function getReadLink() {
     try {
       const tokenResponse = await api.httpQuery(
-        "POST",
-        "/control/generate-user-read-token"
+        HTTP_QUERIES.generateUserReadToken
       );
       const json = await tokenResponse.json();
       const token = json.token;

--- a/web/control/VerifyXlsxSignature.js
+++ b/web/control/VerifyXlsxSignature.js
@@ -13,6 +13,7 @@ import * as Sentry from "@sentry/browser";
 import Alert from "@material-ui/lab/Alert";
 import AlertTitle from "@material-ui/lab/AlertTitle";
 import { useSnackbarAlerts } from "../common/Snackbar";
+import { HTTP_QUERIES } from "common/utils/apiQueries";
 
 const STATUS_MAP = {
   SUCCESS: {
@@ -151,8 +152,7 @@ export function XlsxVerifier() {
       fd.append("xlsx-to-check", file);
       try {
         const apiResponse = await api.httpQuery(
-          "POST",
-          "/control/verify-xlsx-signature",
+          HTTP_QUERIES.verifyXlsxSignature,
           {
             body: fd,
             timeout: 15000

--- a/web/home/ChangeEmail.js
+++ b/web/home/ChangeEmail.js
@@ -1,21 +1,23 @@
 import React from "react";
 import Dialog from "@material-ui/core/Dialog";
 import DialogContent from "@material-ui/core/DialogContent";
-import TextField from "@material-ui/core/TextField";
 import { LoadingButton } from "common/components/LoadingButton";
 import {
   CustomDialogActions,
   CustomDialogTitle
 } from "../common/CustomDialogTitle";
 import { useSnackbarAlerts } from "../common/Snackbar";
+import { EmailField } from "../common/EmailField";
 
 export default function ChangeEmailModal({ open, handleClose, handleSubmit }) {
   const [email, setEmail] = React.useState("");
+  const [error, setError] = React.useState(null);
 
   const alerts = useSnackbarAlerts();
 
   React.useEffect(() => {
     setEmail("");
+    setError(null);
   }, [open]);
 
   return (
@@ -35,21 +37,24 @@ export default function ChangeEmailModal({ open, handleClose, handleSubmit }) {
         }}
       >
         <DialogContent>
-          <TextField
+          <EmailField
             required
             fullWidth
             className="vertical-form-text-input"
             label="Email"
-            type="email"
-            autoComplete="username"
             value={email}
-            onChange={e => {
-              setEmail(e.target.value.replace(/\s/g, ""));
-            }}
+            validate
+            setValue={setEmail}
+            error={error}
+            setError={setError}
           />
         </DialogContent>
         <CustomDialogActions>
-          <LoadingButton type="submit" disabled={!email} color="primary">
+          <LoadingButton
+            type="submit"
+            disabled={error || !email}
+            color="primary"
+          >
             Enregistrer
           </LoadingButton>
         </CustomDialogActions>

--- a/web/home/ChangeEmail.js
+++ b/web/home/ChangeEmail.js
@@ -11,13 +11,13 @@ import { EmailField } from "../common/EmailField";
 
 export default function ChangeEmailModal({ open, handleClose, handleSubmit }) {
   const [email, setEmail] = React.useState("");
-  const [error, setError] = React.useState(null);
+  const [error, setError] = React.useState("");
 
   const alerts = useSnackbarAlerts();
 
   React.useEffect(() => {
     setEmail("");
-    setError(null);
+    setError("");
   }, [open]);
 
   return (

--- a/web/landing/NewsletterSubscription.js
+++ b/web/landing/NewsletterSubscription.js
@@ -13,6 +13,7 @@ import { EmailField } from "../common/EmailField";
 import { useSnackbarAlerts } from "../common/Snackbar";
 import { useApi } from "common/utils/api";
 import makeStyles from "@material-ui/core/styles/makeStyles";
+import { HTTP_QUERIES } from "common/utils/apiQueries";
 
 const useStyles = makeStyles(theme => ({
   caption: {
@@ -60,7 +61,7 @@ export default function NewsletterSubscriptionModal({ open, handleClose }) {
     e.preventDefault();
     setLoading(true);
     await alerts.withApiErrorHandling(async () => {
-      await api.httpQuery("POST", "/contacts/subscribe-to-newsletter", {
+      await api.httpQuery(HTTP_QUERIES.subscribeToNewsletter, {
         json: { list: profile === "others" ? "admins" : profile, email }
       });
       await alerts.success(

--- a/web/landing/NewsletterSubscription.js
+++ b/web/landing/NewsletterSubscription.js
@@ -1,0 +1,133 @@
+import React from "react";
+import Dialog from "@material-ui/core/Dialog";
+import { LoadingButton } from "common/components/LoadingButton";
+import {
+  CustomDialogActions,
+  CustomDialogTitle
+} from "../common/CustomDialogTitle";
+import DialogContent from "@material-ui/core/DialogContent";
+import MenuItem from "@material-ui/core/MenuItem";
+import TextField from "common/utils/TextField";
+import Typography from "@material-ui/core/Typography";
+import { EmailField } from "../common/EmailField";
+import { useSnackbarAlerts } from "../common/Snackbar";
+import { useApi } from "common/utils/api";
+import makeStyles from "@material-ui/core/styles/makeStyles";
+
+const useStyles = makeStyles(theme => ({
+  caption: {
+    marginTop: theme.spacing(2),
+    display: "block",
+    color: theme.palette.grey[600]
+  }
+}));
+
+const PROFILES = [
+  {
+    name: "employees",
+    label: "Travailleur mobile"
+  },
+  {
+    name: "admins",
+    label: "Gestionnaire"
+  },
+  {
+    name: "controllers",
+    label: "Contrôleur"
+  },
+  {
+    name: "softwares",
+    label: "Editeur de logiciel"
+  },
+  {
+    name: "others",
+    label: "Autre"
+  }
+];
+
+export default function NewsletterSubscriptionModal({ open, handleClose }) {
+  const [profile, setProfile] = React.useState(null);
+  const [email, setEmail] = React.useState("");
+  const [emailError, setEmailError] = React.useState(null);
+  const [loading, setLoading] = React.useState(false);
+
+  const api = useApi();
+  const alerts = useSnackbarAlerts();
+
+  const classes = useStyles();
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setLoading(true);
+    await alerts.withApiErrorHandling(async () => {
+      await api.httpQuery("POST", "/contacts/subscribe-to-newsletter", {
+        json: { list: profile === "others" ? "admins" : profile, email }
+      });
+      await alerts.success(
+        "Inscription à la Newsletter réussie !",
+        "subscribe-to-nl",
+        6000
+      );
+    }, "subscribe-to-nl");
+    setLoading(false);
+    handleClose();
+  }
+
+  return (
+    <Dialog onClose={handleClose} open={open}>
+      <form autoComplete="off" onSubmit={handleSubmit}>
+        <CustomDialogTitle
+          handleClose={handleClose}
+          title="Inscription à la newsletter"
+        />
+        <DialogContent>
+          <Typography>
+            Veuillez renseigner votre adresse email pour vous inscrire à notre
+            newsletter
+          </Typography>
+          <EmailField
+            required
+            fullWidth
+            className="vertical-form-text-input"
+            label="Email"
+            value={email}
+            setValue={setEmail}
+            validate
+            error={emailError}
+            setError={setEmailError}
+          />
+          <TextField
+            label="Profil"
+            required
+            fullWidth
+            select
+            value={profile}
+            onChange={e => setProfile(e.target.value)}
+          >
+            {PROFILES.map(prof => (
+              <MenuItem key={prof.name} value={prof.name}>
+                {prof.label}
+              </MenuItem>
+            ))}
+          </TextField>
+          <Typography variant="caption" className={classes.caption}>
+            Vous pouvez vous désinscrire à tout moment en cliquant sur le lien
+            présent dans nos emails.
+          </Typography>
+        </DialogContent>
+        <CustomDialogActions>
+          <LoadingButton
+            aria-label="Inscription"
+            color="primary"
+            type="submit"
+            variant="contained"
+            disabled={emailError || !email || !profile}
+            loading={loading}
+          >
+            Inscription
+          </LoadingButton>
+        </CustomDialogActions>
+      </form>
+    </Dialog>
+  );
+}

--- a/web/landing/NewsletterSubscription.js
+++ b/web/landing/NewsletterSubscription.js
@@ -46,9 +46,9 @@ const PROFILES = [
 ];
 
 export default function NewsletterSubscriptionModal({ open, handleClose }) {
-  const [profile, setProfile] = React.useState(null);
+  const [profile, setProfile] = React.useState("");
   const [email, setEmail] = React.useState("");
-  const [emailError, setEmailError] = React.useState(null);
+  const [emailError, setEmailError] = React.useState("");
   const [loading, setLoading] = React.useState(false);
 
   const api = useApi();

--- a/web/landing/ResetPassword.js
+++ b/web/landing/ResetPassword.js
@@ -5,7 +5,6 @@ import makeStyles from "@material-ui/core/styles/makeStyles";
 import { useHistory, useLocation } from "react-router-dom";
 import { useApi } from "common/utils/api";
 import Typography from "@material-ui/core/Typography";
-import TextField from "@material-ui/core/TextField/TextField";
 import { LoadingButton } from "common/components/LoadingButton";
 import Box from "@material-ui/core/Box";
 import { graphQLErrorMatchesCode } from "common/utils/errors";
@@ -21,6 +20,7 @@ import {
   REQUEST_RESET_PASSWORD_MUTATION,
   RESET_PASSWORD_MUTATION
 } from "common/utils/apiQueries";
+import { EmailField } from "../common/EmailField";
 
 const useStyles = makeStyles(theme => ({
   introText: {
@@ -264,17 +264,13 @@ export function RequestResetPassword() {
                   l'adresse email avec laquelle vous vous êtes inscrits sur
                   Mobilic.
                 </Typography>
-                <TextField
+                <EmailField
                   required
                   fullWidth
                   className="vertical-form-text-input"
                   label="Adresse email de connexion"
-                  type="email"
-                  autoComplete="username"
                   value={email}
-                  onChange={e => {
-                    setEmail(e.target.value.replace(/\s/g, ""));
-                  }}
+                  setValue={setEmail}
                 />
                 <Box my={4}>
                   <LoadingButton

--- a/web/landing/footer.js
+++ b/web/landing/footer.js
@@ -8,6 +8,7 @@ import makeStyles from "@material-ui/core/styles/makeStyles";
 import Container from "@material-ui/core/Container";
 import Hidden from "@material-ui/core/Hidden";
 import { SocialNetworkPanel } from "../common/Header";
+import Button from "@material-ui/core/Button";
 
 const useStyles = makeStyles(theme => ({
   section: {
@@ -46,6 +47,18 @@ const useStyles = makeStyles(theme => ({
   },
   socialNetworkTitle: {
     marginBottom: theme.spacing(1)
+  },
+  darkButton: {
+    backgroundColor: "inherit",
+    color: theme.palette.primary.contrastText,
+    borderColor: theme.palette.primary.contrastText,
+    "&:hover": {
+      backgroundColor: theme.palette.background.default,
+      color: theme.palette.text.primary
+    }
+  },
+  nlButtonContainer: {
+    alignSelf: "center"
   }
 }));
 
@@ -66,65 +79,22 @@ export function Footer() {
           justify="space-between"
           alignItems="flex-start"
         >
-          <Grid
-            item
-            sm={5}
-            container
-            alignItems="center"
-            spacing={4}
-            direction="column"
-          >
-            <Grid
-              item
-              container
-              wrap="nowrap"
-              spacing={2}
-              direction="row"
-              alignItems="flex-start"
-            >
+          <Grid item md={4} sm={12}>
+            <Grid container direction="column" alignItems="center" spacing={4}>
               <Grid item>
-                <FabNumIcon scale={0.5} />
-              </Grid>
-              <Grid item>
-                <Typography align="justify">
-                  Mobilic est un service numérique de l'Etat incubé à la
-                  Fabrique Numérique du Ministère de la Transition écologique,
-                  membre du réseau d’incubateurs{" "}
-                  {
-                    <Link
-                      className={classes.betaGouvLink}
-                      href="https://beta.gouv.fr"
-                    >
-                      beta.gouv.fr
-                    </Link>
-                  }
-                  .
+                <Typography variant="h4">
+                  Recevez la newsletter pour rester informé des nouveautés
+                  Mobilic
                 </Typography>
               </Grid>
-            </Grid>
-            <Grid
-              item
-              container
-              wrap="nowrap"
-              spacing={2}
-              direction="row"
-              alignItems="flex-start"
-            >
               <Grid item>
-                <MarianneIcon
-                  style={{ width: 70, height: 70, backgroundColor: "white" }}
-                  htmlColor="black"
-                />
-              </Grid>
-              <Grid item>
-                <Typography align="justify">
-                  Mobilic est une initiative soutenue par la Direction générale
-                  des infrastructures des transports et de la mer (DGITM).
-                </Typography>
+                <Button className={classes.darkButton} variant="outlined">
+                  S'inscrire !
+                </Button>
               </Grid>
             </Grid>
           </Grid>
-          <Grid item className={classes.footerLinksSection}>
+          <Grid md={4} sm={6} item className={classes.footerLinksSection}>
             <Typography
               variant="h4"
               className={classes.footerLinksSectionTitle}
@@ -181,7 +151,7 @@ export function Footer() {
             </Typography>
           </Grid>
           <Hidden xsDown>
-            <Grid item>
+            <Grid md={4} sm={6} item>
               <Typography
                 variant="h4"
                 align="left"
@@ -196,6 +166,61 @@ export function Footer() {
               />
             </Grid>
           </Hidden>
+          <Grid item xs={12} container alignItems="flex-start" spacing={4}>
+            <Grid
+              item
+              container
+              sm={6}
+              xs={12}
+              wrap="nowrap"
+              spacing={2}
+              direction="row"
+              alignItems="flex-start"
+            >
+              <Grid item>
+                <FabNumIcon scale={0.5} />
+              </Grid>
+              <Grid item>
+                <Typography align="justify">
+                  Mobilic est un service numérique de l'Etat incubé à la
+                  Fabrique Numérique du Ministère de la Transition écologique,
+                  membre du réseau d’incubateurs{" "}
+                  {
+                    <Link
+                      className={classes.betaGouvLink}
+                      href="https://beta.gouv.fr"
+                    >
+                      beta.gouv.fr
+                    </Link>
+                  }
+                  .
+                </Typography>
+              </Grid>
+            </Grid>
+            <Grid
+              item
+              container
+              sm={6}
+              xs={12}
+              wrap="nowrap"
+              spacing={2}
+              direction="row"
+              alignItems="flex-start"
+            >
+              <Grid item>
+                <MarianneIcon
+                  style={{ width: 70, height: 70, backgroundColor: "white" }}
+                  htmlColor="black"
+                />
+              </Grid>
+              <Grid item>
+                <Typography align="justify">
+                  Mobilic est une initiative soutenue par la Direction générale
+                  des infrastructures des transports et de la mer (DGITM).
+                </Typography>
+              </Grid>
+            </Grid>
+          </Grid>
         </Grid>
       </Container>
       <Container className={classes.socialNetworkContainer}>

--- a/web/landing/footer.js
+++ b/web/landing/footer.js
@@ -88,7 +88,11 @@ export function Footer() {
                 </Typography>
               </Grid>
               <Grid item>
-                <Button className={classes.darkButton} variant="outlined">
+                <Button
+                  className={classes.darkButton}
+                  variant="outlined"
+                  onClick={() => modals.open("newsletterSubscription")}
+                >
                   S'inscrire !
                 </Button>
               </Grid>

--- a/web/landing/footer.js
+++ b/web/landing/footer.js
@@ -83,7 +83,7 @@ export function Footer() {
             <Grid container direction="column" alignItems="center" spacing={4}>
               <Grid item>
                 <Typography variant="h4">
-                  Recevez la newsletter pour rester informé des nouveautés
+                  Recevez la newsletter pour rester informé(e) des nouveautés
                   Mobilic
                 </Typography>
               </Grid>

--- a/web/landing/landing.js
+++ b/web/landing/landing.js
@@ -215,8 +215,8 @@ export function Landing() {
           l'enregistrement du temps de travail des conducteurs de véhicules
           utilitaires légers de moins de 3,5 tonnes, et des autres personnels
           roulants non conducteurs, souffre de problèmes unanimement décriés
-          (praticabilité pour le salarié, lourdeur administrative et de gestion,
-          faible fiabilité pour le contrôle). Avec Mobilic{" "}
+          (praticabilité pour les salarié(e)s, lourdeur administrative et de
+          gestion, faible fiabilité pour le contrôle). Avec Mobilic{" "}
           <a
             href="https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043023481"
             target="_blank"
@@ -262,7 +262,7 @@ export function Landing() {
             imagePosition="left"
             imageDescription="Travailleur mobile"
             imageSubDescription="Conducteurs et autres personnels roulants"
-            descriptionTitle="Suivre simplement mon temps de travail et être mieux informé sur mes droits"
+            descriptionTitle="Suivre simplement mon temps de travail et être mieux informé(e) sur mes droits"
             descriptionContent={
               <div
                 style={{
@@ -298,8 +298,8 @@ export function Landing() {
             image={<ManagerImage height={200} width={200} />}
             imagePosition="right"
             imageDescription="Gestionnaire"
-            imageSubDescription="Responsables d'exploitation, dirigeants"
-            descriptionTitle="Gérer facilement le temps de travail des salariés de mon entreprise"
+            imageSubDescription="Responsables d'exploitation, dirigeant(e)s"
+            descriptionTitle="Gérer facilement le temps de travail des salarié(e)s de mon entreprise"
             descriptionContent={
               <ul
                 style={{

--- a/web/landing/login.js
+++ b/web/landing/login.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { useHistory } from "react-router-dom";
-import TextField from "@material-ui/core/TextField";
 import Container from "@material-ui/core/Container";
 import { useApi } from "common/utils/api";
 import Typography from "@material-ui/core/Typography";
@@ -20,6 +19,7 @@ import makeStyles from "@material-ui/core/styles/makeStyles";
 import { useSnackbarAlerts } from "../common/Snackbar";
 import { PaperContainer, PaperContainerTitle } from "../common/PaperContainer";
 import { LOGIN_MUTATION } from "common/utils/apiQueries";
+import { EmailField } from "../common/EmailField";
 
 const useStyles = makeStyles(theme => ({
   forgotPasswordLink: {
@@ -81,16 +81,13 @@ export default function Login() {
             noValidate
             onSubmit={handleSubmit}
           >
-            <TextField
+            <EmailField
               fullWidth
               className="vertical-form-text-input"
               label="Email"
-              type="email"
               autoComplete="username"
               value={email}
-              onChange={e => {
-                setEmail(e.target.value.replace(/\s/g, ""));
-              }}
+              setValue={setEmail}
               required
             />
             <PasswordField

--- a/web/landing/oauth/Consent.js
+++ b/web/landing/oauth/Consent.js
@@ -9,6 +9,7 @@ import Container from "@material-ui/core/Container";
 import { Section } from "../../common/Section";
 import { LoadingButton } from "common/components/LoadingButton";
 import Grid from "@material-ui/core/Grid";
+import { HTTP_QUERIES } from "common/utils/apiQueries";
 
 const useStyles = makeStyles(theme => ({
   title: {
@@ -46,10 +47,9 @@ export function Consent({ clientName, redirectUri }) {
 
   async function handleAuthorize(deny = false) {
     try {
-      const apiResponse = await api.httpQuery(
-        "GET",
-        `/oauth/authorize${location.search}${deny ? "&deny=true" : ""}`
-      );
+      const apiResponse = await api.httpQuery(HTTP_QUERIES.oauthAuthorize, {
+        search: `${location.search}${deny ? "&deny=true" : ""}`
+      });
       const json = await apiResponse.json();
       window.location.href = json.uri;
     } catch (err) {

--- a/web/landing/signup/AccountCreation.js
+++ b/web/landing/signup/AccountCreation.js
@@ -19,6 +19,9 @@ import { PasswordField } from "common/components/PasswordField";
 import { useSnackbarAlerts } from "../../common/Snackbar";
 import { PaperContainerTitle } from "../../common/PaperContainer";
 import { USER_SIGNUP_MUTATION } from "common/utils/apiQueries";
+import FormControlLabel from "@material-ui/core/FormControlLabel/FormControlLabel";
+import Checkbox from "@material-ui/core/Checkbox/Checkbox";
+import FormGroup from "@material-ui/core/FormGroup/FormGroup";
 
 export function AccountCreation({ employeeInvite, isAdmin }) {
   const api = useApi();
@@ -31,6 +34,9 @@ export function AccountCreation({ employeeInvite, isAdmin }) {
   const [lastName, setLastName] = React.useState("");
   const [email, setEmail] = React.useState("");
   const [password, setPassword] = React.useState("");
+  const [subscribeToNewsletter, setSubscribeToNewsletter] = React.useState(
+    true
+  );
   const [loading, setLoading] = React.useState(false);
 
   const handleSubmit = async e => {
@@ -42,7 +48,8 @@ export function AccountCreation({ employeeInvite, isAdmin }) {
         email,
         password,
         firstName,
-        lastName
+        lastName,
+        subscribeToNewsletter
       );
     } else {
       modals.open("cgu", {
@@ -53,7 +60,8 @@ export function AccountCreation({ employeeInvite, isAdmin }) {
             email,
             password,
             firstName,
-            lastName
+            lastName,
+            subscribeToNewsletter
           ),
         handleReject: () => {}
       });
@@ -66,7 +74,8 @@ export function AccountCreation({ employeeInvite, isAdmin }) {
     email,
     password,
     firstName,
-    lastName
+    lastName,
+    subscribeToNewsletter
   ) => {
     setLoading(true);
     await alerts.withApiErrorHandling(
@@ -75,7 +84,8 @@ export function AccountCreation({ employeeInvite, isAdmin }) {
           email,
           password,
           firstName: firstName.trim(),
-          lastName: lastName.trim()
+          lastName: lastName.trim(),
+          subscribeToNewsletter
         };
         if (employeeInvite) {
           signupPayload.inviteToken = employeeInvite.inviteToken;
@@ -172,6 +182,23 @@ export function AccountCreation({ employeeInvite, isAdmin }) {
               setLastName(e.target.value.trimLeft());
             }}
           />
+          <FormGroup style={{ marginTop: 16, marginBottom: 32 }}>
+            <FormControlLabel
+              style={{ alignItems: "flex-start", textAlign: "left" }}
+              control={
+                <Checkbox
+                  required
+                  color="primary"
+                  style={{ paddingTop: 0 }}
+                  checked={subscribeToNewsletter}
+                  onChange={() =>
+                    setSubscribeToNewsletter(!subscribeToNewsletter)
+                  }
+                />
+              }
+              label={`Je souhaite m'inscrire à la newsletter Mobilic pour rester informé par mail des dernières évolutions du produit.`}
+            />
+          </FormGroup>
           <Box my={4}>
             <LoadingButton
               aria-label="Inscription"

--- a/web/landing/signup/AccountCreation.js
+++ b/web/landing/signup/AccountCreation.js
@@ -183,7 +183,7 @@ export function AccountCreation({ employeeInvite, isAdmin }) {
           <CheckboxField
             checked={subscribeToNewsletter}
             onChange={() => setSubscribeToNewsletter(!subscribeToNewsletter)}
-            label="Je souhaite m'inscrire à la newsletter Mobilic pour rester informé par mail des dernières évolutions du produit"
+            label="Je souhaite m'inscrire à la newsletter Mobilic pour rester informé par mail des nouveautés du produit"
           />
           <Box my={4}>
             <LoadingButton

--- a/web/landing/signup/AccountCreation.js
+++ b/web/landing/signup/AccountCreation.js
@@ -20,6 +20,7 @@ import { useSnackbarAlerts } from "../../common/Snackbar";
 import { PaperContainerTitle } from "../../common/PaperContainer";
 import { USER_SIGNUP_MUTATION } from "common/utils/apiQueries";
 import { CheckboxField } from "../../common/CheckboxField";
+import { EmailField } from "../../common/EmailField";
 
 export function AccountCreation({ employeeInvite, isAdmin }) {
   const api = useApi();
@@ -31,6 +32,7 @@ export function AccountCreation({ employeeInvite, isAdmin }) {
   const [firstName, setFirstName] = React.useState("");
   const [lastName, setLastName] = React.useState("");
   const [email, setEmail] = React.useState("");
+  const [emailError, setEmailError] = React.useState("");
   const [password, setPassword] = React.useState("");
   const [subscribeToNewsletter, setSubscribeToNewsletter] = React.useState(
     true
@@ -135,24 +137,22 @@ export function AccountCreation({ employeeInvite, isAdmin }) {
           autoComplete="off"
           onSubmit={handleSubmit}
         >
-          <TextField
+          <EmailField
             required
             fullWidth
             className="vertical-form-text-input"
             label="Email"
-            type="email"
-            autoComplete="username"
             value={email}
-            onChange={e => {
-              setEmail(e.target.value.replace(/\s/g, ""));
-            }}
+            setValue={setEmail}
+            validate
+            error={emailError}
+            setError={setEmailError}
           />
           <PasswordField
             required
             fullWidth
             className="vertical-form-text-input"
             label="Choisissez un mot de passe"
-            autoComplete="current-password"
             value={password}
             onChange={e => {
               setPassword(e.target.value);
@@ -191,7 +191,9 @@ export function AccountCreation({ employeeInvite, isAdmin }) {
               variant="contained"
               color="primary"
               type="submit"
-              disabled={!email || !password || !firstName || !lastName}
+              disabled={
+                emailError || !email || !password || !firstName || !lastName
+              }
               loading={loading}
             >
               M'inscrire

--- a/web/landing/signup/AccountCreation.js
+++ b/web/landing/signup/AccountCreation.js
@@ -19,9 +19,7 @@ import { PasswordField } from "common/components/PasswordField";
 import { useSnackbarAlerts } from "../../common/Snackbar";
 import { PaperContainerTitle } from "../../common/PaperContainer";
 import { USER_SIGNUP_MUTATION } from "common/utils/apiQueries";
-import FormControlLabel from "@material-ui/core/FormControlLabel/FormControlLabel";
-import Checkbox from "@material-ui/core/Checkbox/Checkbox";
-import FormGroup from "@material-ui/core/FormGroup/FormGroup";
+import { CheckboxField } from "../../common/CheckboxField";
 
 export function AccountCreation({ employeeInvite, isAdmin }) {
   const api = useApi();
@@ -182,23 +180,11 @@ export function AccountCreation({ employeeInvite, isAdmin }) {
               setLastName(e.target.value.trimLeft());
             }}
           />
-          <FormGroup style={{ marginTop: 16, marginBottom: 32 }}>
-            <FormControlLabel
-              style={{ alignItems: "flex-start", textAlign: "left" }}
-              control={
-                <Checkbox
-                  required
-                  color="primary"
-                  style={{ paddingTop: 0 }}
-                  checked={subscribeToNewsletter}
-                  onChange={() =>
-                    setSubscribeToNewsletter(!subscribeToNewsletter)
-                  }
-                />
-              }
-              label={`Je souhaite m'inscrire à la newsletter Mobilic pour rester informé par mail des dernières évolutions du produit.`}
-            />
-          </FormGroup>
+          <CheckboxField
+            checked={subscribeToNewsletter}
+            onChange={() => setSubscribeToNewsletter(!subscribeToNewsletter)}
+            label="Je souhaite m'inscrire à la newsletter Mobilic pour rester informé par mail des dernières évolutions du produit"
+          />
           <Box my={4}>
             <LoadingButton
               aria-label="Inscription"

--- a/web/landing/signup/CompanySignup.js
+++ b/web/landing/signup/CompanySignup.js
@@ -16,14 +16,12 @@ import {
   broadCastChannel,
   useStoreSyncedWithLocalStorage
 } from "common/utils/store";
-import FormControlLabel from "@material-ui/core/FormControlLabel";
-import Checkbox from "@material-ui/core/Checkbox";
-import FormGroup from "@material-ui/core/FormGroup";
 import { useSnackbarAlerts } from "../../common/Snackbar";
 import { PaperContainerTitle } from "../../common/PaperContainer";
 import SignupStepper from "./SignupStepper";
 import { COMPANY_SIGNUP_MUTATION, SIREN_QUERY } from "common/utils/apiQueries";
 import { Link } from "../../common/LinkButton";
+import { CheckboxField } from "../../common/CheckboxField";
 
 const useStyles = makeStyles(theme => ({
   formFieldTitle: {
@@ -347,20 +345,12 @@ export function CompanySignup() {
               value={usualName}
               onChange={e => setUsualName(e.target.value.trimLeft())}
             />
-            <FormGroup>
-              <FormControlLabel
-                style={{ textAlign: "left" }}
-                control={
-                  <Checkbox
-                    required
-                    color="primary"
-                    checked={claimedRights}
-                    onChange={() => setClaimedRights(!claimedRights)}
-                  />
-                }
-                label="J'atteste être habilité(e) à administrer l'entreprise"
-              />
-            </FormGroup>
+            <CheckboxField
+              checked={claimedRights}
+              onChange={() => setClaimedRights(!claimedRights)}
+              label="J'atteste être habilité(e) à administrer l'entreprise"
+              required
+            />
             <LoadingButton
               aria-label="Terminer inscription"
               className={classes.verticalFormButton}

--- a/web/landing/signup/EmailSelection.js
+++ b/web/landing/signup/EmailSelection.js
@@ -1,7 +1,6 @@
 import React from "react";
 import Box from "@material-ui/core/Box";
 import Typography from "@material-ui/core/Typography";
-import TextField from "@material-ui/core/TextField/TextField";
 import { useApi } from "common/utils/api";
 import { useHistory, useLocation } from "react-router-dom";
 import {
@@ -19,6 +18,7 @@ import { useSnackbarAlerts } from "../../common/Snackbar";
 import { PaperContainerTitle } from "../../common/PaperContainer";
 import { CONFIRM_FC_EMAIL_MUTATION } from "common/utils/apiQueries";
 import { CheckboxField } from "../../common/CheckboxField";
+import { EmailField } from "../../common/EmailField";
 
 const useStyles = makeStyles(theme => ({
   text: {
@@ -39,6 +39,7 @@ export function EmailSelection() {
 
   const [isAdmin, setIsAdmin] = React.useState(false);
   const [email, setEmail] = React.useState("");
+  const [emailError, setEmailError] = React.useState(null);
   const [origEmailSet, setOrigEmailSet] = React.useState(false);
   const [password, setPassword] = React.useState("");
   const [choosePassword, setChoosePassword] = React.useState(false);
@@ -144,17 +145,16 @@ export function EmailSelection() {
             contact uniquement pour vous communiquer des informations
             indispensables au bon fonctionnement du service.
           </Typography>
-          <TextField
+          <EmailField
             required
             fullWidth
             className="vertical-form-text-input"
             label="Adresse e-mail"
-            type="email"
-            autoComplete="username"
             value={email}
-            onChange={e => {
-              setEmail(e.target.value.replace(/\s/g, ""));
-            }}
+            setValue={setEmail}
+            validate
+            error={emailError}
+            setError={setEmailError}
           />
           <CheckboxField
             checked={subscribeToNewsletter}
@@ -201,7 +201,7 @@ export function EmailSelection() {
             color="primary"
             type="submit"
             loading={loading}
-            disabled={!email || (choosePassword && !password)}
+            disabled={emailError || !email || (choosePassword && !password)}
           >
             Continuer
           </LoadingButton>

--- a/web/landing/signup/EmailSelection.js
+++ b/web/landing/signup/EmailSelection.js
@@ -159,7 +159,7 @@ export function EmailSelection() {
           <CheckboxField
             checked={subscribeToNewsletter}
             onChange={() => setSubscribeToNewsletter(!subscribeToNewsletter)}
-            label="Je souhaite m'inscrire à la newsletter Mobilic pour rester informé par mail des dernières évolutions du produit"
+            label="Je souhaite m'inscrire à la newsletter Mobilic pour rester informé par mail des nouveautés du produit"
           />
         </Section>
         <Section title="2. Mot de passe (facultatif)">

--- a/web/landing/signup/EmailSelection.js
+++ b/web/landing/signup/EmailSelection.js
@@ -14,13 +14,11 @@ import Container from "@material-ui/core/Container";
 import { LoadingButton } from "common/components/LoadingButton";
 import { Section } from "../../common/Section";
 import { useModals } from "common/utils/modals";
-import Checkbox from "@material-ui/core/Checkbox/Checkbox";
-import FormControlLabel from "@material-ui/core/FormControlLabel/FormControlLabel";
-import FormGroup from "@material-ui/core/FormGroup";
 import { PasswordField } from "common/components/PasswordField";
 import { useSnackbarAlerts } from "../../common/Snackbar";
 import { PaperContainerTitle } from "../../common/PaperContainer";
 import { CONFIRM_FC_EMAIL_MUTATION } from "common/utils/apiQueries";
+import { CheckboxField } from "../../common/CheckboxField";
 
 const useStyles = makeStyles(theme => ({
   text: {
@@ -92,7 +90,7 @@ export function EmailSelection() {
           { context: { nonPublicApi: true } }
         );
         if (subscribeToNewsletter) {
-          await api.httpQuery("POST", "/contacts/subscribe_to_newsletter", {
+          await api.httpQuery("POST", "/contacts/subscribe-to-newsletter", {
             json: { list: "employees" }
           });
         }
@@ -158,23 +156,11 @@ export function EmailSelection() {
               setEmail(e.target.value.replace(/\s/g, ""));
             }}
           />
-          <FormGroup style={{ marginTop: 16, marginBottom: 32 }}>
-            <FormControlLabel
-              style={{ alignItems: "flex-start", textAlign: "left" }}
-              control={
-                <Checkbox
-                  required
-                  color="primary"
-                  style={{ paddingTop: 0 }}
-                  checked={subscribeToNewsletter}
-                  onChange={() =>
-                    setSubscribeToNewsletter(!subscribeToNewsletter)
-                  }
-                />
-              }
-              label={`Je souhaite m'inscrire à la newsletter Mobilic pour rester informé par mail des dernières évolutions du produit.`}
-            />
-          </FormGroup>
+          <CheckboxField
+            checked={subscribeToNewsletter}
+            onChange={() => setSubscribeToNewsletter(!subscribeToNewsletter)}
+            label="Je souhaite m'inscrire à la newsletter Mobilic pour rester informé par mail des dernières évolutions du produit"
+          />
         </Section>
         <Section title="2. Mot de passe (facultatif)">
           <Typography align="justify" className={classes.text}>
@@ -186,21 +172,14 @@ export function EmailSelection() {
             Le nom d'utilisateur associé sera l'adresse email renseignée
             ci-dessus.
           </Typography>
-          <FormGroup>
-            <FormControlLabel
-              control={
-                <Checkbox
-                  color="primary"
-                  checked={choosePassword}
-                  onChange={() => {
-                    if (choosePassword) setPassword("");
-                    setChoosePassword(!choosePassword);
-                  }}
-                />
-              }
-              label="Choisir un mot de passe"
-            />
-          </FormGroup>
+          <CheckboxField
+            checked={choosePassword}
+            onChange={() => {
+              if (choosePassword) setPassword("");
+              setChoosePassword(!choosePassword);
+            }}
+            label="Choisir un mot de passe"
+          />
           {choosePassword && (
             <PasswordField
               reuired

--- a/web/landing/signup/EmailSelection.js
+++ b/web/landing/signup/EmailSelection.js
@@ -44,6 +44,9 @@ export function EmailSelection() {
   const [origEmailSet, setOrigEmailSet] = React.useState(false);
   const [password, setPassword] = React.useState("");
   const [choosePassword, setChoosePassword] = React.useState(false);
+  const [subscribeToNewsletter, setSubscribeToNewsletter] = React.useState(
+    true
+  );
   const [loading, setLoading] = React.useState(false);
 
   const location = useLocation();
@@ -88,7 +91,11 @@ export function EmailSelection() {
           payload,
           { context: { nonPublicApi: true } }
         );
-
+        if (subscribeToNewsletter) {
+          await api.httpQuery("POST", "/contacts/subscribe_to_newsletter", {
+            json: { list: "employees" }
+          });
+        }
         await store.setUserInfo({
           ...userInfo,
           ...apiResponse.data.signUp.confirmFcEmail
@@ -135,9 +142,9 @@ export function EmailSelection() {
             )}
           </Typography>
           <Typography align="justify" className={classes.text}>
-            Mobilic se servira de cette adresse comme point de contact
-            uniquement pour vous communiquer des informations indispensables au
-            bon fonctionnement du service.
+            Par défaut Mobilic se servira de cette adresse comme point de
+            contact uniquement pour vous communiquer des informations
+            indispensables au bon fonctionnement du service.
           </Typography>
           <TextField
             required
@@ -151,6 +158,23 @@ export function EmailSelection() {
               setEmail(e.target.value.replace(/\s/g, ""));
             }}
           />
+          <FormGroup style={{ marginTop: 16, marginBottom: 32 }}>
+            <FormControlLabel
+              style={{ alignItems: "flex-start", textAlign: "left" }}
+              control={
+                <Checkbox
+                  required
+                  color="primary"
+                  style={{ paddingTop: 0 }}
+                  checked={subscribeToNewsletter}
+                  onChange={() =>
+                    setSubscribeToNewsletter(!subscribeToNewsletter)
+                  }
+                />
+              }
+              label={`Je souhaite m'inscrire à la newsletter Mobilic pour rester informé par mail des dernières évolutions du produit.`}
+            />
+          </FormGroup>
         </Section>
         <Section title="2. Mot de passe (facultatif)">
           <Typography align="justify" className={classes.text}>

--- a/web/landing/signup/EmailSelection.js
+++ b/web/landing/signup/EmailSelection.js
@@ -1,6 +1,7 @@
 import React from "react";
 import Box from "@material-ui/core/Box";
 import Typography from "@material-ui/core/Typography";
+import * as Sentry from "@sentry/browser";
 import { useApi } from "common/utils/api";
 import { useHistory, useLocation } from "react-router-dom";
 import {
@@ -91,9 +92,13 @@ export function EmailSelection() {
           { context: { nonPublicApi: true } }
         );
         if (subscribeToNewsletter) {
-          await api.httpQuery("POST", "/contacts/subscribe-to-newsletter", {
-            json: { list: "employees" }
-          });
+          try {
+            await api.httpQuery("POST", "/contacts/subscribe-to-newsletter", {
+              json: { list: "employees" }
+            });
+          } catch (err) {
+            Sentry.captureException(err);
+          }
         }
         await store.setUserInfo({
           ...userInfo,

--- a/web/landing/signup/EmailSelection.js
+++ b/web/landing/signup/EmailSelection.js
@@ -40,7 +40,7 @@ export function EmailSelection() {
 
   const [isAdmin, setIsAdmin] = React.useState(false);
   const [email, setEmail] = React.useState("");
-  const [emailError, setEmailError] = React.useState(null);
+  const [emailError, setEmailError] = React.useState("");
   const [origEmailSet, setOrigEmailSet] = React.useState(false);
   const [password, setPassword] = React.useState("");
   const [choosePassword, setChoosePassword] = React.useState(false);

--- a/web/landing/signup/EmailSelection.js
+++ b/web/landing/signup/EmailSelection.js
@@ -17,7 +17,10 @@ import { useModals } from "common/utils/modals";
 import { PasswordField } from "common/components/PasswordField";
 import { useSnackbarAlerts } from "../../common/Snackbar";
 import { PaperContainerTitle } from "../../common/PaperContainer";
-import { CONFIRM_FC_EMAIL_MUTATION } from "common/utils/apiQueries";
+import {
+  CONFIRM_FC_EMAIL_MUTATION,
+  HTTP_QUERIES
+} from "common/utils/apiQueries";
 import { CheckboxField } from "../../common/CheckboxField";
 import { EmailField } from "../../common/EmailField";
 
@@ -93,7 +96,7 @@ export function EmailSelection() {
         );
         if (subscribeToNewsletter) {
           try {
-            await api.httpQuery("POST", "/contacts/subscribe-to-newsletter", {
+            await api.httpQuery(HTTP_QUERIES.subscribeToNewsletter, {
               json: { list: "employees" }
             });
           } catch (err) {

--- a/web/modals.js
+++ b/web/modals.js
@@ -22,6 +22,7 @@ import KilometerReadingModal from "./pwa/components/KilometerReadingModal";
 import SelectEmployeeModal from "./admin/components/SelectEmployee";
 import PDFExport from "./pwa/components/PDFExport";
 import BatchInvite from "./admin/components/BatchInvite";
+import NewsletterSubscriptionModal from "./landing/NewsletterSubscription";
 
 export const MODAL_DICT = {
   firstActivity: FirstActivitySelectionModal,
@@ -47,5 +48,6 @@ export const MODAL_DICT = {
   userReadQRCode: UserReadQRCodeModal,
   unavailableOfflineMode: UnavailableOfflineModeModal,
   kilometerReading: KilometerReadingModal,
-  selectEmployee: SelectEmployeeModal
+  selectEmployee: SelectEmployeeModal,
+  newsletterSubscription: NewsletterSubscriptionModal
 };

--- a/web/pwa/components/PDFExport.js
+++ b/web/pwa/components/PDFExport.js
@@ -21,6 +21,7 @@ import {
   startOfDayAsDate,
   startOfMonthAsDate
 } from "common/utils/time";
+import { HTTP_QUERIES } from "common/utils/apiQueries";
 
 const useStyles = makeStyles(theme => ({
   start: {
@@ -159,11 +160,9 @@ export default function PDFExport({ open, handleClose }) {
               linkType: "download"
             });
             try {
-              await api.downloadFileHttpQuery(
-                "POST",
-                `/users/generate_pdf_export`,
-                { json: options }
-              );
+              await api.downloadFileHttpQuery(HTTP_QUERIES.pdfExport, {
+                json: options
+              });
             } catch (err) {
               alerts.error(formatApiError(err), "generate_pdf_export", 6000);
             }


### PR DESCRIPTION
Cette PR permet à des prospects de s'inscrire à la newsletter depuis la landing sans forcément avoir de compte. De plus lors de la création d'un compte Mobilic on vient demander un consentement pour la réception de la newsletter.

Pour faciliter la review voici un détail des changements :

* ajout d'une modal `NewsletterSubscriptionModal` avec un formulaire pour souscrire à la NL

* ajout d'un bouton dans le `footer.js` pour accéder à cette modal

* refacto du champ `EmailField` utilisé un peu partout, avec ajout d'une logique de validation des adresses tapées

* refacto du champ `CheckboxField` utilisé notamment pour le consentement aux mails dans un formulaire

Trello : https://trello.com/c/1AMlbBu4/337-etq-gestionnaire-je-peux-minscrire-%C3%A0-la-nl-mobilic-m%C3%AAme-sans-avoir-de-compte