### PR TITLE
Feature/non zero duration activities

### DIFF
--- a/common/components/DateOrDateTimeRangeSelectionContext.js
+++ b/common/components/DateOrDateTimeRangeSelectionContext.js
@@ -1,0 +1,32 @@
+import React from "react";
+
+export function DateOrDateTimeRangeSelectionContext({
+  start,
+  setStart,
+  end,
+  setEnd,
+  minRangeSize,
+  nullableBounds = false,
+  children
+}) {
+  const isRangeInvalid = () => {
+    if (!nullableBounds && (!start || !end)) {
+      return true;
+    }
+    return (
+      start && end && (minRangeSize ? start > end - minRangeSize : start > end)
+    );
+  };
+
+  React.useEffect(() => {
+    if (start && isRangeInvalid())
+      setEnd(minRangeSize ? start + minRangeSize : start);
+  }, [start]);
+
+  React.useEffect(() => {
+    if (end && isRangeInvalid())
+      setStart(minRangeSize ? end - minRangeSize : end);
+  }, [end]);
+
+  return children;
+}

--- a/common/utils/activities.js
+++ b/common/utils/activities.js
@@ -1,6 +1,9 @@
 import React from "react";
 import { RestIcon, TruckIcon, WorkIcon } from "./icons";
 import { now } from "./time";
+import forEach from "lodash/forEach";
+import maxBy from "lodash/maxBy";
+import minBy from "lodash/minBy";
 
 export const SWITCH_ACTIVITIES = {
   drive: {
@@ -92,4 +95,145 @@ export function getActivityStartTimeToUse(
     switchTimeDelta <= 60
     ? latestActivitySwitchExactTime
     : latestActivitySwitchTime;
+}
+
+export function convertBreakIntoActivityOperations(
+  allActivities,
+  startTime,
+  endTime,
+  selfId,
+  extendActivities = false
+) {
+  const activities = allActivities.filter(a => a.userId === selfId);
+
+  const activitiesStartedBeforeEndingInBetween = activities.filter(
+    a =>
+      a.startTime < startTime &&
+      ((!endTime && (!a.endTime || a.endTime > startTime)) ||
+        (endTime && a.endTime && a.endTime > startTime && a.endTime <= endTime))
+  );
+  const activitiesPurelyInBetween = activities.filter(
+    a =>
+      a.startTime >= startTime &&
+      (!endTime || (a.endTime && a.endTime > startTime && a.endTime <= endTime))
+  );
+  const activitiesStartedInBetweenEndingAfter = activities.filter(
+    a =>
+      a.startTime >= startTime &&
+      endTime &&
+      a.startTime < endTime &&
+      (!a.endTime || a.endTime > endTime)
+  );
+  const activitiesFullyOverlapping = activities
+    .filter(
+      a =>
+        a.startTime < startTime &&
+        endTime &&
+        (!a.endTime || a.endTime > endTime)
+    )
+    .map(a => {
+      let driverId;
+      if ([ACTIVITIES.drive.name, ACTIVITIES.support.name].includes(a.type)) {
+        const siblingActivities = allActivities.filter(
+          a1 =>
+            a1.userId !== a.userId &&
+            a1.startTime === a.startTime &&
+            a1.endTime === a.endTime
+        );
+
+        driverId = -1;
+        forEach(siblingActivities, a1 => {
+          if (a1.type === ACTIVITIES.drive.name) driverId = a1.userId;
+          return false;
+        });
+      }
+      return { ...a, driverId };
+    });
+
+  let ops = [];
+  activitiesStartedBeforeEndingInBetween.forEach(a =>
+    ops.push({
+      activity: a,
+      operation: "update",
+      startTime: a.startTime,
+      endTime: startTime
+    })
+  );
+  activitiesPurelyInBetween.forEach(a =>
+    ops.push({
+      activity: a,
+      operation: "cancel"
+    })
+  );
+  activitiesStartedInBetweenEndingAfter.forEach(a =>
+    ops.push({
+      activity: a,
+      operation: "update",
+      startTime: endTime,
+      endTime: a.endTime
+    })
+  );
+  activitiesFullyOverlapping.forEach(a => {
+    if (startTime < endTime)
+      ops.push(
+        {
+          activity: a,
+          operation: "update",
+          startTime: a.startTime,
+          endTime: startTime
+        },
+        {
+          operation: "create",
+          type: a.type,
+          startTime: endTime,
+          endTime: a.endTime
+        }
+      );
+  });
+
+  if (extendActivities) {
+    if (
+      activitiesStartedBeforeEndingInBetween.length +
+        activitiesFullyOverlapping.length ===
+      0
+    ) {
+      const activitiesStartedBefore = activities.filter(
+        a => a.startTime < startTime
+      );
+      const activityRightBefore =
+        activitiesStartedBefore.length > 0
+          ? maxBy(activitiesStartedBefore, a => a.endTime)
+          : null;
+      if (activityRightBefore && activityRightBefore.endTime < startTime) {
+        ops.push({
+          activity: activityRightBefore,
+          operation: "update",
+          startTime: activityRightBefore.startTime,
+          endTime: startTime
+        });
+      }
+    }
+    if (
+      activitiesFullyOverlapping.length +
+        activitiesStartedInBetweenEndingAfter.length ===
+      0
+    ) {
+      const activitiesEndedAfter = activities.filter(
+        a => endTime && (!a.endTime || a.endTime > endTime)
+      );
+      const activityRightAfter =
+        activitiesEndedAfter.length > 0
+          ? minBy(activitiesEndedAfter, a => a.startTime)
+          : null;
+      if (activityRightAfter && activityRightAfter.startTime > endTime) {
+        ops.push({
+          activity: activityRightAfter,
+          operation: "update",
+          startTime: endTime,
+          endTime: activityRightAfter.endTime
+        });
+      }
+    }
+  }
+  return ops;
 }

--- a/common/utils/errors.js
+++ b/common/utils/errors.js
@@ -131,6 +131,8 @@ export function defaultFormatGraphQLApiError(graphQLError, store) {
               )}`
             : "d'autres activités"
         }.`;
+      case "EMPTY_ACTIVITY_DURATION":
+        return `L'heure de fin de l'activité doit être strictement après l'heure de début`;
       case "INVALID_EMAIL_ADDRESS":
         return `L'adresse email n'est pas valide`;
       case "MISSION_ALREADY_ENDED":

--- a/common/utils/time.js
+++ b/common/utils/time.js
@@ -236,3 +236,10 @@ export function isoFormatLocalDate(date) {
     date.getDate()
   )}`;
 }
+
+export function sameMinute(unixTimestamp1, unixTimestamp2) {
+  return (
+    new Date(unixTimestamp1 * 1000).toISOString().slice(0, 16) ===
+    new Date(unixTimestamp2 * 1000).toISOString().slice(0, 16)
+  );
+}

--- a/web/admin/components/C1BExport.js
+++ b/web/admin/components/C1BExport.js
@@ -21,6 +21,7 @@ import Switch from "@material-ui/core/Switch/Switch";
 import { DAY, isoFormatLocalDate } from "common/utils/time";
 import Alert from "@material-ui/lab/Alert";
 import { HTTP_QUERIES } from "common/utils/apiQueries";
+import { DateOrDateTimeRangeSelectionContext } from "common/components/DateOrDateTimeRangeSelectionContext";
 
 const useStyles = makeStyles(theme => ({
   start: {
@@ -73,14 +74,6 @@ export default function C1BExport({
       );
     } else setDateRangeError(null);
   }, [minDate, maxDate]);
-
-  React.useEffect(() => {
-    if (minDate && maxDate && maxDate < minDate) setMaxDate(minDate);
-  }, [minDate]);
-
-  React.useEffect(() => {
-    if (maxDate && minDate && minDate > maxDate) setMinDate(maxDate);
-  }, [maxDate]);
 
   const [_companies, setCompanies] = React.useState([]);
   const [_users, setUsers] = React.useState([]);
@@ -165,42 +158,46 @@ export default function C1BExport({
           >
             <EmployeeFilter users={_users} setUsers={setUsers} />
           </Grid>
-          <Grid item sm={6}>
-            <DatePicker
-              required
-              label="Date de début"
-              value={minDate}
-              format="d MMMM yyyy"
-              onChange={setMinDate}
-              clearable
-              cancelLabel={null}
-              clearLabel="Annuler"
-              autoOk
-              disableFuture
-              inputVariant="outlined"
-              animateYearScrolling
-              error={!!dateRangeError}
-              helperText={dateRangeError}
-            />
-          </Grid>
-          <Grid item sm={6}>
-            <DatePicker
-              required
-              label="Date de fin"
-              value={maxDate}
-              format="d MMMM yyyy"
-              onChange={setMaxDate}
-              clearable
-              cancelLabel={null}
-              clearLabel="Annuler"
-              autoOk
-              disableFuture
-              inputVariant="outlined"
-              animateYearScrolling
-              error={!!dateRangeError}
-              helperText={dateRangeError}
-            />
-          </Grid>
+          <DateOrDateTimeRangeSelectionContext
+            start={minDate}
+            setStart={setMinDate}
+            end={maxDate}
+            setEnd={setMaxDate}
+            nullableBounds={false}
+          >
+            <Grid item sm={6}>
+              <DatePicker
+                required
+                label="Date de début"
+                value={minDate}
+                format="d MMMM yyyy"
+                onChange={setMinDate}
+                cancelLabel={null}
+                autoOk
+                disableFuture
+                inputVariant="outlined"
+                animateYearScrolling
+                error={!!dateRangeError}
+                helperText={dateRangeError}
+              />
+            </Grid>
+            <Grid item sm={6}>
+              <DatePicker
+                required
+                label="Date de fin"
+                value={maxDate}
+                format="d MMMM yyyy"
+                onChange={setMaxDate}
+                cancelLabel={null}
+                autoOk
+                disableFuture
+                inputVariant="outlined"
+                animateYearScrolling
+                error={!!dateRangeError}
+                helperText={dateRangeError}
+              />
+            </Grid>
+          </DateOrDateTimeRangeSelectionContext>
           <Grid item xs={12}>
             <Box className={classes.switchContainer}>
               <Switch

--- a/web/admin/components/ExcelExport.js
+++ b/web/admin/components/ExcelExport.js
@@ -17,6 +17,7 @@ import { useMatomo } from "@datapunt/matomo-tracker-react";
 import Grid from "@material-ui/core/Grid";
 import { isoFormatLocalDate } from "common/utils/time";
 import { HTTP_QUERIES } from "common/utils/apiQueries";
+import { DateOrDateTimeRangeSelectionContext } from "common/components/DateOrDateTimeRangeSelectionContext";
 
 const useStyles = makeStyles(theme => ({
   start: {
@@ -61,14 +62,6 @@ export default function ExcelExport({
     setMinDate(defaultMinDate);
     setMaxDate(defaultMaxDate);
   }, [open]);
-
-  React.useEffect(() => {
-    if (minDate && maxDate && maxDate < minDate) setMaxDate(minDate);
-  }, [minDate]);
-
-  React.useEffect(() => {
-    if (maxDate && minDate && minDate > maxDate) setMinDate(maxDate);
-  }, [maxDate]);
 
   const classes = useStyles();
 
@@ -126,36 +119,44 @@ export default function ExcelExport({
           >
             <EmployeeFilter users={_users} setUsers={setUsers} />
           </Grid>
-          <Grid item sm={6}>
-            <DatePicker
-              label="Date de début"
-              value={minDate}
-              format="d MMMM yyyy"
-              onChange={setMinDate}
-              clearable
-              cancelLabel={null}
-              clearLabel="Annuler"
-              autoOk
-              disableFuture
-              inputVariant="outlined"
-              animateYearScrolling
-            />
-          </Grid>
-          <Grid item sm={6}>
-            <DatePicker
-              label="Date de fin"
-              value={maxDate}
-              format="d MMMM yyyy"
-              onChange={setMaxDate}
-              clearable
-              cancelLabel={null}
-              clearLabel="Annuler"
-              autoOk
-              disableFuture
-              inputVariant="outlined"
-              animateYearScrolling
-            />
-          </Grid>
+          <DateOrDateTimeRangeSelectionContext
+            start={minDate}
+            setStart={setMinDate}
+            end={maxDate}
+            setEnd={setMaxDate}
+            nullableBounds
+          >
+            <Grid item sm={6}>
+              <DatePicker
+                label="Date de début"
+                value={minDate}
+                format="d MMMM yyyy"
+                onChange={setMinDate}
+                clearable
+                cancelLabel={null}
+                clearLabel="Annuler"
+                autoOk
+                disableFuture
+                inputVariant="outlined"
+                animateYearScrolling
+              />
+            </Grid>
+            <Grid item sm={6}>
+              <DatePicker
+                label="Date de fin"
+                value={maxDate}
+                format="d MMMM yyyy"
+                onChange={setMaxDate}
+                clearable
+                cancelLabel={null}
+                clearLabel="Annuler"
+                autoOk
+                disableFuture
+                inputVariant="outlined"
+                animateYearScrolling
+              />
+            </Grid>
+          </DateOrDateTimeRangeSelectionContext>
         </Grid>
       </DialogContent>
       <CustomDialogActions>

--- a/web/admin/components/MissionDetails.js
+++ b/web/admin/components/MissionDetails.js
@@ -16,7 +16,10 @@ import Divider from "@material-ui/core/Divider";
 import flatMap from "lodash/flatMap";
 import { AugmentedTable } from "./AugmentedTable";
 import { formatPersonName } from "common/utils/coworkers";
-import { ACTIVITIES } from "common/utils/activities";
+import {
+  ACTIVITIES,
+  convertBreakIntoActivityOperations
+} from "common/utils/activities";
 import { DateOrDateTimePicker } from "../../pwa/components/DateOrDateTimePicker";
 import { useApi } from "common/utils/api";
 import { useAdminStore } from "../utils/store";
@@ -33,7 +36,6 @@ import {
   isGraphQLError
 } from "common/utils/errors";
 import Button from "@material-ui/core/Button";
-import { addBreakOps } from "../../pwa/components/ActivityRevision";
 import {
   CANCEL_ACTIVITY_MUTATION,
   CANCEL_COMMENT_MUTATION,
@@ -216,7 +218,7 @@ export function MissionDetails({
   async function onCancelActivity(activity, user, activities) {
     if (setShouldRefreshActivityPanel) setShouldRefreshActivityPanel(true);
     if (activity.type === ACTIVITIES.break.name) {
-      const ops = addBreakOps(
+      const ops = convertBreakIntoActivityOperations(
         activities,
         activity.endTime,
         activity.endTime,
@@ -263,7 +265,7 @@ export function MissionDetails({
   async function onCreateActivity(user, newValues, activities) {
     if (setShouldRefreshActivityPanel) setShouldRefreshActivityPanel(true);
     if (newValues.type === ACTIVITIES.break.name) {
-      const ops = addBreakOps(
+      const ops = convertBreakIntoActivityOperations(
         activities,
         newValues.startTime,
         newValues.endTime,
@@ -318,7 +320,7 @@ export function MissionDetails({
   async function onEditActivity(activity, newValues, user, activities) {
     if (setShouldRefreshActivityPanel) setShouldRefreshActivityPanel(true);
     if (activity.type === ACTIVITIES.break.name) {
-      const ops = addBreakOps(
+      const ops = convertBreakIntoActivityOperations(
         activities,
         newValues.startTime,
         newValues.endTime,
@@ -520,7 +522,7 @@ export function MissionDetails({
         <DateOrDateTimePicker
           label="Fin"
           value={time}
-          minValue={entry.startTime - 1}
+          minValue={entry.startTime + 1}
           autoValidate
           maxValue={now()}
           setValue={setTime}

--- a/web/pwa/components/ActivityRevision.js
+++ b/web/pwa/components/ActivityRevision.js
@@ -5,13 +5,13 @@ import Box from "@material-ui/core/Box";
 import { now } from "common/utils/time";
 import DialogContent from "@material-ui/core/DialogContent";
 import TextField from "common/utils/TextField";
-import { ACTIVITIES } from "common/utils/activities";
+import {
+  ACTIVITIES,
+  convertBreakIntoActivityOperations
+} from "common/utils/activities";
 import uniq from "lodash/uniq";
 import min from "lodash/min";
 import max from "lodash/max";
-import maxBy from "lodash/maxBy";
-import minBy from "lodash/minBy";
-import forEach from "lodash/forEach";
 import MenuItem from "@material-ui/core/MenuItem";
 import { formatPersonName, resolveTeamAt } from "common/utils/coworkers";
 import { useStoreSyncedWithLocalStorage } from "common/utils/store";
@@ -26,147 +26,7 @@ import Button from "@material-ui/core/Button";
 import makeStyles from "@material-ui/core/styles/makeStyles";
 import { useModals } from "common/utils/modals";
 import { LoadingButton } from "common/components/LoadingButton";
-
-export function addBreakOps(
-  allActivities,
-  startTime,
-  endTime,
-  selfId,
-  extendActivities = false
-) {
-  const activities = allActivities.filter(a => a.userId === selfId);
-
-  const activitiesStartedBeforeEndingInBetween = activities.filter(
-    a =>
-      a.startTime < startTime &&
-      ((!endTime && (!a.endTime || a.endTime > startTime)) ||
-        (endTime && a.endTime && a.endTime > startTime && a.endTime <= endTime))
-  );
-  const activitiesPurelyInBetween = activities.filter(
-    a =>
-      a.startTime >= startTime &&
-      (!endTime || (a.endTime && a.endTime > startTime && a.endTime <= endTime))
-  );
-  const activitiesStartedInBetweenEndingAfter = activities.filter(
-    a =>
-      a.startTime >= startTime &&
-      endTime &&
-      a.startTime < endTime &&
-      (!a.endTime || a.endTime > endTime)
-  );
-  const activitiesFullyOverlapping = activities
-    .filter(
-      a =>
-        a.startTime < startTime &&
-        endTime &&
-        (!a.endTime || a.endTime > endTime)
-    )
-    .map(a => {
-      let driverId;
-      if ([ACTIVITIES.drive.name, ACTIVITIES.support.name].includes(a.type)) {
-        const siblingActivities = allActivities.filter(
-          a1 =>
-            a1.userId !== a.userId &&
-            a1.startTime === a.startTime &&
-            a1.endTime === a.endTime
-        );
-
-        driverId = -1;
-        forEach(siblingActivities, a1 => {
-          if (a1.type === ACTIVITIES.drive.name) driverId = a1.userId;
-          return false;
-        });
-      }
-      return { ...a, driverId };
-    });
-
-  let ops = [];
-  activitiesStartedBeforeEndingInBetween.forEach(a =>
-    ops.push({
-      activity: a,
-      operation: "update",
-      startTime: a.startTime,
-      endTime: startTime
-    })
-  );
-  activitiesPurelyInBetween.forEach(a =>
-    ops.push({
-      activity: a,
-      operation: "cancel"
-    })
-  );
-  activitiesStartedInBetweenEndingAfter.forEach(a =>
-    ops.push({
-      activity: a,
-      operation: "update",
-      startTime: endTime,
-      endTime: a.endTime
-    })
-  );
-  activitiesFullyOverlapping.forEach(a => {
-    if (startTime < endTime)
-      ops.push(
-        {
-          activity: a,
-          operation: "update",
-          startTime: a.startTime,
-          endTime: startTime
-        },
-        {
-          operation: "create",
-          type: a.type,
-          startTime: endTime,
-          endTime: a.endTime
-        }
-      );
-  });
-
-  if (extendActivities) {
-    if (
-      activitiesStartedBeforeEndingInBetween.length +
-        activitiesFullyOverlapping.length ===
-      0
-    ) {
-      const activitiesStartedBefore = activities.filter(
-        a => a.startTime < startTime
-      );
-      const activityRightBefore =
-        activitiesStartedBefore.length > 0
-          ? maxBy(activitiesStartedBefore, a => a.endTime)
-          : null;
-      if (activityRightBefore && activityRightBefore.endTime < startTime) {
-        ops.push({
-          activity: activityRightBefore,
-          operation: "update",
-          startTime: activityRightBefore.startTime,
-          endTime: startTime
-        });
-      }
-    }
-    if (
-      activitiesFullyOverlapping.length +
-        activitiesStartedInBetweenEndingAfter.length ===
-      0
-    ) {
-      const activitiesEndedAfter = activities.filter(
-        a => endTime && (!a.endTime || a.endTime > endTime)
-      );
-      const activityRightAfter =
-        activitiesEndedAfter.length > 0
-          ? minBy(activitiesEndedAfter, a => a.startTime)
-          : null;
-      if (activityRightAfter && activityRightAfter.startTime > endTime) {
-        ops.push({
-          activity: activityRightAfter,
-          operation: "update",
-          startTime: endTime,
-          endTime: activityRightAfter.endTime
-        });
-      }
-    }
-  }
-  return ops;
-}
+import { DateOrDateTimeRangeSelectionContext } from "common/components/DateOrDateTimeRangeSelectionContext";
 
 const useStyles = makeStyles(theme => ({
   formField: {
@@ -242,7 +102,7 @@ export default function ActivityRevisionOrCreationModal({
 
   async function handleSubmit(actionType) {
     if (activityType === ACTIVITIES.break.name) {
-      const ops = addBreakOps(
+      const ops = convertBreakIntoActivityOperations(
         otherActivities,
         actionType === "cancel" ? event.endTime : newUserTime,
         actionType === "cancel" ? event.endTime : newUserEndTime,
@@ -331,14 +191,9 @@ export default function ActivityRevisionOrCreationModal({
         setNewUserTimeError(`L'heure ne peut pas être dans le futur.`);
       }
 
-      if (newUserEndTime) {
-        if (newUserEndTime < newUserTime) {
-          hasEndError = true;
-          setNewUserEndTimeError("La fin doit être après le début");
-        } else if (newUserEndTime > now()) {
-          hasEndError = true;
-          setNewUserEndTimeError(`L'heure ne peut pas être dans le futur.`);
-        }
+      if (newUserEndTime && newUserEndTime > now()) {
+        hasEndError = true;
+        setNewUserEndTimeError(`L'heure ne peut pas être dans le futur.`);
       }
 
       if (!hasStartError && !hasEndError) {
@@ -526,33 +381,42 @@ export default function ActivityRevisionOrCreationModal({
               </MenuItem>
             </TextField>
           )}
-          <DateOrDateTimePicker
-            key={0}
-            label="Début"
-            variant="filled"
-            className={classes.formField}
-            value={newUserTime}
-            setValue={setNewUserTime}
-            error={newUserTimeError}
-            minValue={previousMissionEnd}
-            maxValue={nextMissionStart}
-            required
-            noValidate
-          />
-          <DateOrDateTimePicker
-            key={1}
-            label="Fin"
-            variant="filled"
-            className={classes.formField}
-            required={!actuallyNullableEndTime}
-            value={newUserEndTime}
-            minValue={newUserTime}
-            maxValue={nextMissionStart}
-            setValue={setNewUserEndTime}
-            error={newUserEndTimeError}
-            clearable={actuallyNullableEndTime}
-            noValidate
-          />
+          <DateOrDateTimeRangeSelectionContext
+            start={newUserTime}
+            setStart={setNewUserTime}
+            end={newUserEndTime}
+            setEnd={setNewUserEndTime}
+            nullableBounds
+            minRangeSize={60}
+          >
+            <DateOrDateTimePicker
+              key={0}
+              label="Début"
+              variant="filled"
+              className={classes.formField}
+              value={newUserTime}
+              setValue={setNewUserTime}
+              error={newUserTimeError}
+              minValue={previousMissionEnd}
+              maxValue={nextMissionStart}
+              required
+              noValidate
+            />
+            <DateOrDateTimePicker
+              key={1}
+              label="Fin"
+              variant="filled"
+              className={classes.formField}
+              required={!actuallyNullableEndTime}
+              value={newUserEndTime}
+              minValue={newUserTime}
+              maxValue={nextMissionStart}
+              setValue={setNewUserEndTime}
+              error={newUserEndTimeError}
+              clearable={actuallyNullableEndTime}
+              noValidate
+            />
+          </DateOrDateTimeRangeSelectionContext>
         </Box>
         {allowTeamMode && team.length > 1 && (
           <Box mt={1}>

--- a/web/pwa/components/ActivityRevision.js
+++ b/web/pwa/components/ActivityRevision.js
@@ -2,7 +2,7 @@ import React from "react";
 import Dialog from "@material-ui/core/Dialog";
 import Typography from "@material-ui/core/Typography";
 import Box from "@material-ui/core/Box";
-import { now } from "common/utils/time";
+import { now, sameMinute } from "common/utils/time";
 import DialogContent from "@material-ui/core/DialogContent";
 import TextField from "common/utils/TextField";
 import {
@@ -26,7 +26,6 @@ import Button from "@material-ui/core/Button";
 import makeStyles from "@material-ui/core/styles/makeStyles";
 import { useModals } from "common/utils/modals";
 import { LoadingButton } from "common/components/LoadingButton";
-import { DateOrDateTimeRangeSelectionContext } from "common/components/DateOrDateTimeRangeSelectionContext";
 
 const useStyles = makeStyles(theme => ({
   formField: {
@@ -191,7 +190,15 @@ export default function ActivityRevisionOrCreationModal({
         setNewUserTimeError(`L'heure ne peut pas être dans le futur.`);
       }
 
-      if (newUserEndTime && newUserEndTime > now()) {
+      if (newUserEndTime) {
+        if (
+          newUserEndTime <= newUserTime ||
+          sameMinute(newUserEndTime, newUserTime)
+        ) {
+          hasEndError = true;
+          setNewUserEndTimeError("La fin doit être après le début");
+        }
+      } else if (newUserEndTime > now()) {
         hasEndError = true;
         setNewUserEndTimeError(`L'heure ne peut pas être dans le futur.`);
       }
@@ -381,42 +388,33 @@ export default function ActivityRevisionOrCreationModal({
               </MenuItem>
             </TextField>
           )}
-          <DateOrDateTimeRangeSelectionContext
-            start={newUserTime}
-            setStart={setNewUserTime}
-            end={newUserEndTime}
-            setEnd={setNewUserEndTime}
-            nullableBounds
-            minRangeSize={60}
-          >
-            <DateOrDateTimePicker
-              key={0}
-              label="Début"
-              variant="filled"
-              className={classes.formField}
-              value={newUserTime}
-              setValue={setNewUserTime}
-              error={newUserTimeError}
-              minValue={previousMissionEnd}
-              maxValue={nextMissionStart}
-              required
-              noValidate
-            />
-            <DateOrDateTimePicker
-              key={1}
-              label="Fin"
-              variant="filled"
-              className={classes.formField}
-              required={!actuallyNullableEndTime}
-              value={newUserEndTime}
-              minValue={newUserTime}
-              maxValue={nextMissionStart}
-              setValue={setNewUserEndTime}
-              error={newUserEndTimeError}
-              clearable={actuallyNullableEndTime}
-              noValidate
-            />
-          </DateOrDateTimeRangeSelectionContext>
+          <DateOrDateTimePicker
+            key={0}
+            label="Début"
+            variant="filled"
+            className={classes.formField}
+            value={newUserTime}
+            setValue={setNewUserTime}
+            error={newUserTimeError}
+            minValue={previousMissionEnd}
+            maxValue={nextMissionStart}
+            required
+            noValidate
+          />
+          <DateOrDateTimePicker
+            key={1}
+            label="Fin"
+            variant="filled"
+            className={classes.formField}
+            required={!actuallyNullableEndTime}
+            value={newUserEndTime}
+            minValue={newUserTime}
+            maxValue={nextMissionStart}
+            setValue={setNewUserEndTime}
+            error={newUserEndTimeError}
+            clearable={actuallyNullableEndTime}
+            noValidate
+          />
         </Box>
         {allowTeamMode && team.length > 1 && (
           <Box mt={1}>

--- a/web/pwa/components/PDFExport.js
+++ b/web/pwa/components/PDFExport.js
@@ -22,6 +22,7 @@ import {
   startOfMonthAsDate
 } from "common/utils/time";
 import { HTTP_QUERIES } from "common/utils/apiQueries";
+import { DateOrDateTimeRangeSelectionContext } from "common/components/DateOrDateTimeRangeSelectionContext";
 
 const useStyles = makeStyles(theme => ({
   start: {
@@ -67,14 +68,6 @@ export default function PDFExport({ open, handleClose }) {
     } else setDateRangeError(null);
   }, [minDate, maxDate]);
 
-  React.useEffect(() => {
-    if (minDate && (!maxDate || maxDate < minDate)) setMaxDate(minDate);
-  }, [minDate]);
-
-  React.useEffect(() => {
-    if (maxDate && (!minDate || minDate > maxDate)) setMinDate(maxDate);
-  }, [maxDate]);
-
   const classes = useStyles();
 
   return (
@@ -90,53 +83,55 @@ export default function PDFExport({ open, handleClose }) {
           choix.
         </Typography>
         <Grid spacing={4} container className={classes.grid}>
-          <Grid item sm={6} xs={12}>
-            <DatePicker
-              required
-              label="Mois de début"
-              value={minDate}
-              format="MMMM yyyy"
-              fullWidth
-              onChange={e => {
-                setMinDate(e);
-              }}
-              clearable
-              cancelLabel={null}
-              clearLabel="Annuler"
-              autoOk
-              disableFuture
-              inputVariant="outlined"
-              animateYearScrolling
-              error={!!dateRangeError}
-              helperText={dateRangeError}
-              openTo={"month"}
-              views={["year", "month"]}
-            />
-          </Grid>
-          <Grid item sm={6} xs={12}>
-            <DatePicker
-              required
-              label="Mois de fin"
-              value={maxDate}
-              format="MMMM yyyy"
-              fullWidth
-              onChange={e => {
-                console.log(e);
-                setMaxDate(e);
-              }}
-              clearable
-              cancelLabel={null}
-              clearLabel="Annuler"
-              autoOk
-              disableFuture
-              inputVariant="outlined"
-              animateYearScrolling
-              error={!!dateRangeError}
-              helperText={dateRangeError}
-              openTo={"month"}
-              views={["year", "month"]}
-            />
-          </Grid>
+          <DateOrDateTimeRangeSelectionContext
+            start={minDate}
+            setStart={setMinDate}
+            end={maxDate}
+            setEnd={setMaxDate}
+          >
+            <Grid item sm={6} xs={12}>
+              <DatePicker
+                required
+                label="Mois de début"
+                value={minDate}
+                format="MMMM yyyy"
+                fullWidth
+                onChange={e => {
+                  setMinDate(e);
+                }}
+                cancelLabel={null}
+                autoOk
+                disableFuture
+                inputVariant="outlined"
+                animateYearScrolling
+                error={!!dateRangeError}
+                helperText={dateRangeError}
+                openTo={"month"}
+                views={["year", "month"]}
+              />
+            </Grid>
+            <Grid item sm={6} xs={12}>
+              <DatePicker
+                required
+                label="Mois de fin"
+                value={maxDate}
+                format="MMMM yyyy"
+                fullWidth
+                onChange={e => {
+                  setMaxDate(e);
+                }}
+                cancelLabel={null}
+                autoOk
+                disableFuture
+                inputVariant="outlined"
+                animateYearScrolling
+                error={!!dateRangeError}
+                helperText={dateRangeError}
+                openTo={"month"}
+                views={["year", "month"]}
+              />
+            </Grid>
+          </DateOrDateTimeRangeSelectionContext>
         </Grid>
       </DialogContent>
       <CustomDialogActions>

--- a/web/pwa/screens/CurrentActivity.js
+++ b/web/pwa/screens/CurrentActivity.js
@@ -34,7 +34,7 @@ export function CurrentActivity({
   return [
     <CurrentActivityOverview
       key={0}
-      currentDayStart={currentMission.activities[0].startTime}
+      currentDayStart={currentMission.startTime}
       currentMission={currentMission}
       latestActivity={latestActivity}
     />,


### PR DESCRIPTION
Etant donné que les activités ne sont plus autorisées à avoir une durée nulle côté back (https://github.com/MTES-MCT/mobilic-api/pull/24), le front est mis à jour pour éviter ce cas :

* lorsqu'on change rapidement d'activité l'activité précédente est annulée auprès de l'API (`cancelActivity`) si sa durée est trop courte
* on ne peut plus sélectionner d'heure de fin égale à l'heure de début lorsqu'on édite/crée une activité