### PR TITLE
Remove actions in mission review after employee validation

### DIFF
--- a/common/utils/apiQueries.js
+++ b/common/utils/apiQueries.js
@@ -1120,6 +1120,16 @@ export const MISSION_QUERY = gql`
   }
 `;
 
+export const DISABLE_VALIDATION_WARNING_MUTATION = gql`
+  mutation disableValidationWarning {
+    account {
+      disableWarning(warningName: "employee-validation") {
+        success
+      }
+    }
+  }
+`;
+
 export function buildLogLocationPayloadFromAddress(
   address,
   missionId,

--- a/common/utils/apiQueries.js
+++ b/common/utils/apiQueries.js
@@ -1120,10 +1120,10 @@ export const MISSION_QUERY = gql`
   }
 `;
 
-export const DISABLE_VALIDATION_WARNING_MUTATION = gql`
-  mutation disableValidationWarning {
+export const DISABLE_WARNING_MUTATION = gql`
+  mutation disableValidationWarning($warningName: WarningToDisableTypeEnum!) {
     account {
-      disableWarning(warningName: "employee-validation") {
+      disableWarning(warningName: $warningName) {
         success
       }
     }

--- a/common/utils/loadUserData.js
+++ b/common/utils/loadUserData.js
@@ -22,6 +22,7 @@ const USER_QUERY = gql`
       email
       hasConfirmedEmail
       hasActivatedEmail
+      disabledWarnings
       missions(fromTime: $activityAfter, first: 200) {
         edges {
           node {
@@ -89,6 +90,7 @@ export async function syncUser(userPayload, api, store) {
     birthDate,
     hasConfirmedEmail,
     hasActivatedEmail,
+    disabledWarnings,
     missions: missionsPayload,
     currentEmployments
   } = userPayload;
@@ -131,7 +133,8 @@ export async function syncUser(userPayload, api, store) {
           email,
           birthDate,
           hasConfirmedEmail,
-          hasActivatedEmail
+          hasActivatedEmail,
+          disabledWarnings
         },
         false
       )

--- a/common/utils/store.js
+++ b/common/utils/store.js
@@ -542,7 +542,8 @@ export class StoreSyncedWithLocalStorageProvider extends React.Component {
       email,
       birthDate,
       hasConfirmedEmail,
-      hasActivatedEmail
+      hasActivatedEmail,
+      disabledWarnings
     },
     commitImmediately = true
   ) =>
@@ -555,7 +556,8 @@ export class StoreSyncedWithLocalStorageProvider extends React.Component {
             email,
             birthDate,
             hasConfirmedEmail,
-            hasActivatedEmail
+            hasActivatedEmail,
+            disabledWarnings
           }
         },
         resolve,

--- a/web/common/Confirmation.js
+++ b/web/common/Confirmation.js
@@ -5,10 +5,14 @@ import Dialog from "@material-ui/core/Dialog";
 import IconButton from "@material-ui/core/IconButton";
 import { LoadingButton } from "common/components/LoadingButton";
 import { CustomDialogActions, CustomDialogTitle } from "./CustomDialogTitle";
+import DialogContent from "@material-ui/core/DialogContent";
 
 export default function ConfirmationModal({
   title,
   textButtons,
+  confirmButtonLabel,
+  cancelButtonLabel,
+  content = null,
   open,
   handleClose,
   handleConfirm
@@ -19,30 +23,32 @@ export default function ConfirmationModal({
         title={title || "Confirmer"}
         handleClose={handleClose}
       />
+      {content && <DialogContent>{content}</DialogContent>}
       <CustomDialogActions>
-        {textButtons ? (
+        {cancelButtonLabel || textButtons ? (
           <LoadingButton
             aria-label="Confirmer"
             color="primary"
             onClick={handleClose}
           >
-            Non
+            {cancelButtonLabel || "Non"}
           </LoadingButton>
         ) : (
           <IconButton aria-label="Confirmer" onClick={handleClose}>
             <CloseIcon color="error" />
           </IconButton>
         )}
-        {textButtons ? (
+        {confirmButtonLabel || textButtons ? (
           <LoadingButton
             aria-label="Annuler"
             color="primary"
+            variant="contained"
             onClick={async (...args) => {
               await handleConfirm(...args);
               handleClose();
             }}
           >
-            Oui
+            {confirmButtonLabel || "Oui"}
           </LoadingButton>
         ) : (
           <IconButton

--- a/web/pwa/components/MissionDetails.js
+++ b/web/pwa/components/MissionDetails.js
@@ -163,13 +163,15 @@ export function MissionDetails({
       (!untilTime || new Date(exp.spendingDate).getTime() / 1000 < untilTime)
   );
 
+  const disableActions = mission.validation || mission.adminValidation;
+
   return (
     <AlternateColors inverseColors={inverseColors}>
       <MissionReviewSection
         title="Activités"
         editButtonLabel="Ajouter"
         onEdit={
-          createActivity
+          createActivity && !disableActions
             ? () =>
                 modals.open("activityRevision", {
                   otherActivities: mission.allActivities,
@@ -208,7 +210,7 @@ export function MissionDetails({
         <ActivityList
           activities={mission.activities}
           allMissionActivities={mission.allActivities}
-          editActivityEvent={editActivityEvent}
+          editActivityEvent={!disableActions ? editActivityEvent : null}
           createActivity={args =>
             createActivity({
               ...args,
@@ -231,7 +233,7 @@ export function MissionDetails({
         <MissionReviewSection
           title={`${hasTeamMates ? "Coéquipiers" : "En solo"}`}
           onEdit={
-            allowTeamActions && changeTeam
+            allowTeamActions && changeTeam && !disableActions
               ? () =>
                   modals.open("teamSelection", {
                     mission: mission,
@@ -278,7 +280,7 @@ export function MissionDetails({
       <MissionReviewSection
         title="Véhicule"
         onEdit={
-          editVehicle
+          editVehicle && !disableActions
             ? () =>
                 modals.open("updateVehicle", {
                   handleSubmit: editVehicle,
@@ -317,7 +319,8 @@ export function MissionDetails({
                 mission.company &&
                 mission.company.settings &&
                 mission.company.settings.requireKilometerData &&
-                mission.vehicle
+                mission.vehicle &&
+                !disableActions
                   ? editKilometerReading
                   : null
               }
@@ -331,7 +334,8 @@ export function MissionDetails({
                   mission.company &&
                   mission.company.settings &&
                   mission.company.settings.requireKilometerData &&
-                  mission.vehicle
+                  mission.vehicle &&
+                  !disableActions
                     ? editKilometerReading
                     : null
                 }
@@ -364,7 +368,8 @@ export function MissionDetails({
               editExpenditures &&
               (!mission.company ||
                 !mission.company.settings ||
-                mission.company.settings.requireExpenditures)
+                mission.company.settings.requireExpenditures) &&
+              !disableActions
                 ? () =>
                     modals.open("expenditures", {
                       handleSubmit: (expenditures, forAllTeam) =>

--- a/web/pwa/components/MissionDetails.js
+++ b/web/pwa/components/MissionDetails.js
@@ -35,10 +35,6 @@ import { Comment } from "../../common/Comment";
 import { useSnackbarAlerts } from "../../common/Snackbar";
 import LocationEntry from "./LocationEntry";
 import Alert from "@material-ui/lab/Alert";
-import FormControlLabel from "@material-ui/core/FormControlLabel";
-import Checkbox from "@material-ui/core/Checkbox";
-import { useApi } from "common/utils/api";
-import { DISABLE_VALIDATION_WARNING_MUTATION } from "common/utils/apiQueries";
 
 const useStyles = makeStyles(theme => ({
   backgroundPaper: {
@@ -99,25 +95,6 @@ export function AlternateColors({ children, inverseColors = false }) {
     ));
 }
 
-// Checkbox component that is controlled by parent values but have as well an internal state.
-// This is a hack allowing the component to be passed to a modal and properly rerender with user input (thanks to internal state) while also updating the controlled parent value.
-// We need to do that because the component is passed to the modal as "static" prop and would not otherwise re-render with changes to its own props.
-function CustomCheckbox({ setChecked, checked, ...props }) {
-  const [internalChecked, setInternalChecked] = React.useState(checked);
-
-  React.useEffect(() => {
-    setChecked(internalChecked);
-  }, [internalChecked]);
-
-  return (
-    <Checkbox
-      checked={internalChecked}
-      onChange={() => setInternalChecked(!internalChecked)}
-      {...props}
-    />
-  );
-}
-
 export function MissionDetails({
   mission,
   editActivityEvent,
@@ -148,13 +125,10 @@ export function MissionDetails({
 }) {
   const classes = useStyles();
   const modals = useModals();
-  const api = useApi();
   const store = useStoreSyncedWithLocalStorage();
   const userInfo = store.userInfo();
   const actualUserId = userId || store.userId();
   const alerts = useSnackbarAlerts();
-
-  const disableValidationWarning = React.useRef(false);
 
   const actualCoworkers = coworkers || store.getEntity("coworkers");
 
@@ -206,43 +180,14 @@ export function MissionDetails({
         title: "Confirmer la validation",
         confirmButtonLabel: "Valider",
         cancelButtonLabel: "Annuler",
+        disableWarningName: "employee-validation",
         content: (
-          <>
-            <Typography gutterBottom>
-              ⚠️ Une fois la mission validée vous ne pourrez plus y apporter de
-              modifications.
-            </Typography>
-            <FormControlLabel
-              control={
-                <CustomCheckbox
-                  checked={!!disableValidationWarning.current}
-                  setChecked={value => {
-                    disableValidationWarning.current = value;
-                  }}
-                  size="small"
-                />
-              }
-              label={
-                <Typography variant="caption">
-                  Ne plus afficher ce message
-                </Typography>
-              }
-            />
-          </>
+          <Typography gutterBottom>
+            ⚠️ Une fois la mission validée vous ne pourrez plus y apporter de
+            modifications.
+          </Typography>
         ),
-        handleConfirm: async () => {
-          try {
-            if (disableValidationWarning.current) {
-              await api.graphQlMutate(
-                DISABLE_VALIDATION_WARNING_MUTATION,
-                {},
-                { context: { nonPublicApi: true } }
-              );
-            }
-          } finally {
-            await actualValidationFunc();
-          }
-        }
+        handleConfirm: actualValidationFunc
       });
     } else await actualValidationFunc();
   }

--- a/web/pwa/components/MissionDetails.js
+++ b/web/pwa/components/MissionDetails.js
@@ -102,7 +102,7 @@ export function AlternateColors({ children, inverseColors = false }) {
 // Checkbox component that is controlled by parent values but have as well an internal state.
 // This is a hack allowing the component to be passed to a modal and properly rerender with user input (thanks to internal state) while also updating the controlled parent value.
 // We need to do that because the component is passed to the modal as "static" prop and would not otherwise re-render with changes to its own props.
-function CustomCheckbox({ setChecked, checked }) {
+function CustomCheckbox({ setChecked, checked, ...props }) {
   const [internalChecked, setInternalChecked] = React.useState(checked);
 
   React.useEffect(() => {
@@ -113,6 +113,7 @@ function CustomCheckbox({ setChecked, checked }) {
     <Checkbox
       checked={internalChecked}
       onChange={() => setInternalChecked(!internalChecked)}
+      {...props}
     />
   );
 }

--- a/web/pwa/components/history/Day.js
+++ b/web/pwa/components/history/Day.js
@@ -258,20 +258,10 @@ export function Day({
                   <MissionDetails
                     inverseColors
                     mission={mission}
-                    editActivityEvent={
-                      mission.adminValidation ? null : editActivityEvent
-                    }
-                    createActivity={
-                      mission.adminValidation ? null : createActivity
-                    }
-                    editExpenditures={
-                      mission.adminValidation ? null : editExpenditures
-                    }
-                    editVehicle={
-                      mission.adminValidation || !editVehicle
-                        ? null
-                        : vehicle => editVehicle({ mission, vehicle })
-                    }
+                    editActivityEvent={editActivityEvent}
+                    createActivity={createActivity}
+                    editExpenditures={editExpenditures}
+                    editVehicle={vehicle => editVehicle({ mission, vehicle })}
                     nullableEndTimeInEditActivity={
                       currentMission ? mission.id === currentMission.id : true
                     }
@@ -285,9 +275,7 @@ export function Day({
                     userId={userId}
                     fromTime={selectedPeriodStart}
                     untilTime={selectedPeriodEnd}
-                    editKilometerReading={
-                      mission.adminValidation ? null : registerKilometerReading
-                    }
+                    editKilometerReading={registerKilometerReading}
                   />
                 </MissionSummary>
               </ListItem>

--- a/web/pwa/components/history/Mission.js
+++ b/web/pwa/components/history/Mission.js
@@ -117,16 +117,10 @@ export function Mission({
           <MissionDetails
             inverseColors
             mission={mission}
-            editActivityEvent={
-              mission.adminValidation ? null : editActivityEvent
-            }
-            createActivity={mission.adminValidation ? null : createActivity}
-            editExpenditures={mission.adminValidation ? null : editExpenditures}
-            editVehicle={
-              mission.adminValidation
-                ? null
-                : vehicle => editVehicle({ mission, vehicle })
-            }
+            editActivityEvent={editActivityEvent}
+            createActivity={createActivity}
+            editExpenditures={editExpenditures}
+            editVehicle={vehicle => editVehicle({ mission, vehicle })}
             nullableEndTimeInEditActivity={
               currentMission ? mission.id === currentMission.id : true
             }
@@ -138,9 +132,7 @@ export function Mission({
             coworkers={coworkers}
             vehicles={vehicles}
             userId={userId}
-            editKilometerReading={
-              mission.adminValidation ? null : registerKilometerReading
-            }
+            editKilometerReading={registerKilometerReading}
           />
         </WorkTimeSummaryAdditionalInfo>
       </MissionSummary>


### PR DESCRIPTION
Maintenant que la validation du salarié est bloquante côté back, càd qu'il ne peut plus modifier les données de la mission après validation (https://github.com/MTES-MCT/mobilic-api/pull/25), les actions de modification ne sont plus montrées dans le front :

* ajout/édition d'activités
* modification de frais
* modification du véhicule
* modification du kilométrage
* changement d'équipe