### PR TITLE
Remove "Ambulance" from landing page.

### DIFF
--- a/web/landing/root.js
+++ b/web/landing/root.js
@@ -214,8 +214,8 @@ export const Landing = withWidth()(({ width }) => {
             (LIC)
           </strong>{" "}
           conformément aux articles R. 3312-19, 2° et R. 3312-58, 2° du code des
-          transports : déménagement, ambulance, messagerie, fret express,
-          transport de personnes.
+          transports : déménagement, messagerie, fret express, transport de
+          personnes.
         </Typography>
         <Box className={`${classes.lightBlue}`} p={2}>
           <Showcase


### PR DESCRIPTION
https://trello.com/c/dB1vtxqa/434-supprimer-la-r%C3%A9f%C3%A9rence-au-transport-sanitaire-sur-la-landing