### PR TITLE
Enh/contradictory

### DIFF
--- a/common/store/store.js
+++ b/common/store/store.js
@@ -117,8 +117,7 @@ export class StoreSyncedWithLocalStorageProvider extends React.Component {
     if (msg === "update") {
       this.loadFromStorageQueue.execute(
         async () => await this.loadFromStorage(false),
-        "load",
-        true
+        { cacheKey: "load", refresh: true }
       );
     }
   };

--- a/common/utils/api.js
+++ b/common/utils/api.js
@@ -252,10 +252,9 @@ class Api {
   }
 
   async _queryWithRefreshToken(query) {
-    await this.refreshTokenQueue.execute(
-      () => this._refreshTokenIfNeeded(),
-      "refreshToken"
-    );
+    await this.refreshTokenQueue.execute(() => this._refreshTokenIfNeeded(), {
+      cacheKey: "refreshToken"
+    });
     return await query();
     // No need to catch the refresh-token error since logout is imminent
   }

--- a/common/utils/errors.js
+++ b/common/utils/errors.js
@@ -14,7 +14,7 @@ export function formatApiError(error, overrideFormatGraphQLError) {
   try {
     if (isConnectionError(error)) {
       formattedError =
-        "Impossible de se connecter au serveur. Veuillez réessayer ultérieurement.";
+        "Pas de connection Internet. Veuillez réessayer plus tard.";
     } else if (isGraphQLError(error)) {
       const formattedGraphQLErrors = error.graphQLErrors
         .map(e => formatGraphQLError(e, overrideFormatGraphQLError))
@@ -27,7 +27,7 @@ export function formatApiError(error, overrideFormatGraphQLError) {
   }
   return formattedError
     ? formattedError
-    : "Une erreur est survenue. Veuillez réessayer ultérieurement.";
+    : "Une erreur est survenue. Veuillez réessayer plus tard.";
 }
 
 export function isAuthenticationError(error) {
@@ -94,7 +94,7 @@ export function defaultFormatGraphQLApiError(graphQLError, store) {
       case "SIRET_ALREADY_SIGNED_UP":
         return `L'établissement a déjà été inscrit. Veuillez vous rapprocher de vos collaborateurs administrateurs pour y être rattaché(e)`;
       case "UNAVAILABLE_SIREN_API":
-        return `Recherche impossible actuellement. Veuillez réessayer ultérieurement.`;
+        return `Recherche impossible actuellement. Veuillez réessayer plus tard.`;
       case "NO_SIREN_API_CREDENTIALS":
         return "Recherche impossible.";
       case "FRANCE_CONNECT_ERROR":

--- a/common/utils/loading.js
+++ b/common/utils/loading.js
@@ -16,12 +16,12 @@ export function LoadingScreenContextProvider({ children }) {
     setSyncingWithBackendCounter
   ] = React.useState(0); // We use a counter instead of a boolean because multiple syncs can run simultaneously
 
-  const withLoadingScreen = async (sync, id = null, nonBlocking = false) => {
+  const withLoadingScreen = async (sync, options = {}, nonBlocking = false) => {
     setSyncingWithBackendCounter(currentCounter => currentCounter + 1);
     try {
       if (nonBlocking) await sync();
       else {
-        await loadingFunctionsQueue.execute(sync, id);
+        await loadingFunctionsQueue.execute(sync, options);
       }
       setSyncingWithBackendCounter(currentCounter => currentCounter - 1);
     } catch (err) {

--- a/web/control/VerifyXlsxSignature.js
+++ b/web/control/VerifyXlsxSignature.js
@@ -24,12 +24,11 @@ const STATUS_MAP = {
   INTERNAL_ERROR: {
     title: "ERREUR INTERNE",
     desc:
-      "La vérification d'intégrité n'a pas pu être effectuée à cause d'une erreur interne. Veuillez réessayer ultérieurement."
+      "La vérification d'intégrité n'a pas pu être effectuée à cause d'une erreur interne. Veuillez réessayer plus tard."
   },
   NETWORK_ERROR: {
     title: "ERREUR DE CONNEXION",
-    desc:
-      "Le serveur Mobilic semble injoignable. Veuillez réessayer ultérieurement."
+    desc: "Le serveur Mobilic semble injoignable. Veuillez réessayer plus tard."
   },
   MISSING_FILE: {
     title: "PAS DE FICHIER",
@@ -51,7 +50,7 @@ const STATUS_MAP = {
   UNAVAILABLE: {
     title: "SERVICE NON DISPONIBLE",
     desc:
-      "Impossible d'effectuer la vérification d'intégrité, veuillez réessayer ultérieurement."
+      "Impossible d'effectuer la vérification d'intégrité, veuillez réessayer plus tard."
   }
 };
 

--- a/web/home/RedeemInvite.js
+++ b/web/home/RedeemInvite.js
@@ -29,6 +29,7 @@ export function RedeemInvite() {
   async function redeemInvite(token) {
     await withLoadingScreen(async () => {
       try {
+        const isAuthenticated = await api.checkAuthentication();
         const userId = currentUserId();
         const employment = await api.graphQlQuery(
           GET_EMPLOYMENT_QUERY,
@@ -38,8 +39,12 @@ export function RedeemInvite() {
           { context: { nonPublicApi: true } }
         );
         const employmentUserId = employment.data.employment.userId;
-        let shouldLoadUser = !userId;
-        if (employmentUserId && employmentUserId !== userId) {
+        let shouldLoadUser = !isAuthenticated || !userId;
+        if (
+          employmentUserId &&
+          isAuthenticated &&
+          employmentUserId !== userId
+        ) {
           await api.logout({
             postFCLogoutRedirect: `/logout?next=${encodeURIComponent(
               "/redeem_invite?token=" + token

--- a/web/pwa/components/ContradictoryChanges.js
+++ b/web/pwa/components/ContradictoryChanges.js
@@ -56,25 +56,30 @@ export function ContradictoryChanges({ mission, userId }) {
     // eslint-disable-next-line no-unused-vars
     _,
     changesHistory,
-    loadingEmployeeVersion
-  ] = useToggleContradictory(open, setOpen, [mission]);
+    loadingEmployeeVersion,
+    hasComputedContradictory
+  ] = useToggleContradictory(true, open, setOpen, [mission]);
 
   const userChangesHistory = changesHistory.filter(c => c.userId === userId);
 
   return (
     <>
       <Box mt={1} style={{ display: "flex", justifyContent: "space-between" }}>
-        <Typography className="bold">Voir le contradictoire</Typography>
-        <IconButton
-          aria-label={open ? "Masquer" : "Afficher"}
-          color="inherit"
-          className="no-margin-no-padding"
-          onClick={() => setOpen(!open)}
-        >
-          {open ? <ExpandLessIcon /> : <ExpandMoreIcon />}
-        </IconButton>
+        <Typography className="bold">Modifications gestionnaire</Typography>
+        {(!hasComputedContradictory || changesHistory.length > 0) && (
+          <IconButton
+            aria-label={open ? "Masquer" : "Afficher"}
+            color="inherit"
+            className="no-margin-no-padding"
+            onClick={() => setOpen(!open)}
+          >
+            {open ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+          </IconButton>
+        )}
       </Box>
-      <Collapse in={open}>
+      <Collapse
+        in={open || (changesHistory.length === 0 && hasComputedContradictory)}
+      >
         {loadingEmployeeVersion ? (
           <Skeleton rect width="100%" height={100} />
         ) : userChangesHistory.length === 0 ? (

--- a/web/pwa/components/ContradictorySwitch.js
+++ b/web/pwa/components/ContradictorySwitch.js
@@ -2,12 +2,25 @@ import React from "react";
 import Grid from "@material-ui/core/Grid";
 import Typography from "@material-ui/core/Typography";
 import Switch from "@material-ui/core/Switch/Switch";
+import makeStyles from "@material-ui/core/styles/makeStyles";
+
+const useStyles = makeStyles(theme => ({
+  infoText: {
+    color: "inherit",
+    fontStyle: "italic",
+    opacity: 0.6
+  }
+}));
 
 export function ContradictorySwitch({
+  contradictoryNotYetAvailable,
+  emptyContradictory,
   className,
   shouldDisplayInitialEmployeeVersion,
   setShouldDisplayInitialEmployeeVersion
 }) {
+  const classes = useStyles();
+
   return (
     <Grid
       container
@@ -16,20 +29,32 @@ export function ContradictorySwitch({
       wrap="nowrap"
       className={className}
     >
-      <Grid item>
-        <Typography variant="body2">Après</Typography>
-      </Grid>
-      <Grid item>
-        <Switch
-          checked={shouldDisplayInitialEmployeeVersion}
-          onChange={e =>
-            setShouldDisplayInitialEmployeeVersion(e.target.checked)
-          }
-        />
-      </Grid>
-      <Grid item>
-        <Typography variant="body2">Avant validation gestionnaire</Typography>
-      </Grid>
+      {contradictoryNotYetAvailable || emptyContradictory ? (
+        <Grid item>
+          <Typography className={classes.infoText} align="left" variant="body2">
+            {contradictoryNotYetAvailable
+              ? "Les versions contradictoires ne sont pas encore visibles car la mission n'a pas encore été validée par le gestionnaire"
+              : "Il n'y a pas eu de modifications de la part du gestionnaire"}
+          </Typography>
+        </Grid>
+      ) : (
+        <>
+          <Grid item>
+            <Typography variant="body2">Version gestionnaire</Typography>
+          </Grid>
+          <Grid item>
+            <Switch
+              checked={shouldDisplayInitialEmployeeVersion}
+              onChange={e =>
+                setShouldDisplayInitialEmployeeVersion(e.target.checked)
+              }
+            />
+          </Grid>
+          <Grid item>
+            <Typography variant="body2">Version salarié</Typography>
+          </Grid>
+        </>
+      )}
     </Grid>
   );
 }

--- a/web/pwa/components/history/Day.js
+++ b/web/pwa/components/history/Day.js
@@ -42,12 +42,18 @@ export function Day({
     shouldDisplayInitialEmployeeVersion,
     setShouldDisplayInitialEmployeeVersion
   ] = React.useState(false);
-  const shouldDisplayContradictoryVersionsToggle = missionsInPeriod.every(
+  const canDisplayContradictoryVersions = missionsInPeriod.every(
     mission => mission.adminValidation && mission.validation
   );
 
   // eslint-disable-next-line no-unused-vars
-  const [activitiesToUse, _, loadingEmployeeVersion] = useToggleContradictory(
+  const [
+    activitiesToUse,
+    changes,
+    loadingEmployeeVersion,
+    hasComputedContradictory
+  ] = useToggleContradictory(
+    canDisplayContradictoryVersions,
     shouldDisplayInitialEmployeeVersion,
     setShouldDisplayInitialEmployeeVersion,
     missionsInPeriod
@@ -61,26 +67,23 @@ export function Day({
   ];
 
   React.useEffect(() => {
-    if (
-      !shouldDisplayContradictoryVersionsToggle &&
-      shouldDisplayInitialEmployeeVersion
-    )
+    if (!canDisplayContradictoryVersions && shouldDisplayInitialEmployeeVersion)
       setShouldDisplayInitialEmployeeVersion(false);
-  }, [shouldDisplayContradictoryVersionsToggle]);
+  }, [canDisplayContradictoryVersions]);
 
   return (
     <Box>
-      {shouldDisplayContradictoryVersionsToggle && (
-        <ContradictorySwitch
-          className={classes.contradictorySwitch}
-          shouldDisplayInitialEmployeeVersion={
-            shouldDisplayInitialEmployeeVersion
-          }
-          setShouldDisplayInitialEmployeeVersion={
-            setShouldDisplayInitialEmployeeVersion
-          }
-        />
-      )}
+      <ContradictorySwitch
+        contradictoryNotYetAvailable={!canDisplayContradictoryVersions}
+        emptyContradictory={hasComputedContradictory && changes.length === 0}
+        className={classes.contradictorySwitch}
+        shouldDisplayInitialEmployeeVersion={
+          shouldDisplayInitialEmployeeVersion
+        }
+        setShouldDisplayInitialEmployeeVersion={
+          setShouldDisplayInitialEmployeeVersion
+        }
+      />
       <DaySummary
         activitiesWithNextAndPreviousDay={userActivitiesToUse}
         isDayEnded={true}

--- a/web/pwa/components/history/Mission.js
+++ b/web/pwa/components/history/Mission.js
@@ -61,14 +61,14 @@ export function Mission({
     setShouldDisplayInitialEmployeeVersion
   ] = React.useState(false);
 
-  const shouldDisplayContradictoryVersionsToggle =
+  const canDisplayContradictoryVersions =
     mission.adminValidation && mission.validation;
 
   React.useEffect(() => {
     if (
       shouldDisplayInitialEmployeeVersion !==
         controlledShouldDisplayInitialEmployeeVersion &&
-      shouldDisplayContradictoryVersionsToggle
+      canDisplayContradictoryVersions
     )
       setShouldDisplayInitialEmployeeVersion(
         controlledShouldDisplayInitialEmployeeVersion
@@ -77,10 +77,11 @@ export function Mission({
 
   const [
     activitiesToUse,
-    // eslint-disable-next-line no-unused-vars
-    _,
-    loadingEmployeeVersion
+    changes,
+    loadingEmployeeVersion,
+    hasComputedContradictory
   ] = useToggleContradictory(
+    canDisplayContradictoryVersions,
     shouldDisplayInitialEmployeeVersion,
     setShouldDisplayInitialEmployeeVersion,
     [mission]
@@ -160,17 +161,17 @@ export function Mission({
             </ItalicWarningTypography>
           </InfoCard>
         )}
-        {shouldDisplayContradictoryVersionsToggle && (
-          <ContradictorySwitch
-            className={classes.contradictorySwitch}
-            shouldDisplayInitialEmployeeVersion={
-              shouldDisplayInitialEmployeeVersion
-            }
-            setShouldDisplayInitialEmployeeVersion={
-              setShouldDisplayInitialEmployeeVersion
-            }
-          />
-        )}
+        <ContradictorySwitch
+          contradictoryNotYetAvailable={!canDisplayContradictoryVersions}
+          emptyContradictory={changes.length === 0 && hasComputedContradictory}
+          className={classes.contradictorySwitch}
+          shouldDisplayInitialEmployeeVersion={
+            shouldDisplayInitialEmployeeVersion
+          }
+          setShouldDisplayInitialEmployeeVersion={
+            setShouldDisplayInitialEmployeeVersion
+          }
+        />
         {showMetrics && (
           <WorkTimeSummaryKpiGrid
             loading={loadingEmployeeVersion}

--- a/web/pwa/screens/BeforeWork.js
+++ b/web/pwa/screens/BeforeWork.js
@@ -145,7 +145,7 @@ export function BeforeWork({ beginNewMission, openHistory, missions }) {
             });
             await modals.closeAll();
           },
-          null,
+          {},
           true
         );
       },

--- a/web/pwa/screens/History.js
+++ b/web/pwa/screens/History.js
@@ -453,7 +453,7 @@ export function History({
           value={currentTab}
           onChange={(e, tab) => handlePeriodChange(e, tab, selectedPeriod)}
           style={{ flexGrow: 1 }}
-          variant="fullWdith"
+          variant="fullWidth"
         >
           {Object.values(tabs).map((tabProps, index) => (
             <Tab

--- a/web/root.js
+++ b/web/root.js
@@ -194,7 +194,7 @@ function _Root() {
       async () => {
         if (userId && store.userId()) await loadUserAndRoute();
       },
-      () => (userId && store.userId() ? "loadUser" + store.userId() : null),
+      { cacheKey: "loadUser" + userId },
       false
     );
     return () => {};


### PR DESCRIPTION
Implémentation des suggestions d'améiloration autour de la visualisation du contradictoire (https://trello.com/c/KmOyQWU0/380-comprendre-qui-a-saisi-modifi%C3%A9-quoi-sur-une-journ%C3%A9e-de-travail-salari%C3%A9) :

* Changements de wording

* Maintenant les infos nécessaires au contradictoire sont chargées immédiatement à l'arrivée sur la page, plutôt que d'attendre le toggle

* En cas de contradictoire vide (pas de modifications par le gestionnaire) on affiche un message spécifique et on enlève le toggle