### PR TITLE
Fix for readOnly boolean in mission drawer.

### DIFF
--- a/common/utils/apiQueries.js
+++ b/common/utils/apiQueries.js
@@ -76,6 +76,7 @@ export const FULL_MISSION_FRAGMENT = gql`
   fragment FullMissionData on Mission {
     id
     name
+    submitterId
     validations {
       submitterId
       receptionTime

--- a/common/utils/mission.js
+++ b/common/utils/mission.js
@@ -148,6 +148,9 @@ export function computeMissionStats(m, users) {
 
 export function missionCreatedByAdmin(mission, employments) {
   return employments.some(
-    e => e.hasAdminRights && e.user.id === mission.submitterId
+    e =>
+      e.hasAdminRights &&
+      e.user.id === mission.submitterId &&
+      mission.companyId === e.companyId
   );
 }

--- a/common/utils/mission.js
+++ b/common/utils/mission.js
@@ -145,3 +145,9 @@ export function computeMissionStats(m, users) {
       : {}
   };
 }
+
+export function missionCreatedByAdmin(mission, employments) {
+  return employments.some(
+    e => e.hasAdminRights && e.user.id === mission.submitterId
+  );
+}

--- a/web/admin/components/MissionDetails.js
+++ b/web/admin/components/MissionDetails.js
@@ -62,7 +62,10 @@ import Switch from "@material-ui/core/Switch/Switch";
 import { VerticalTimeline } from "common/components/VerticalTimeline";
 import Grid from "@material-ui/core/Grid";
 import { ActivitiesPieChart } from "common/components/ActivitiesPieChart";
-import { computeMissionStats } from "common/utils/mission";
+import {
+  computeMissionStats,
+  missionCreatedByAdmin
+} from "common/utils/mission";
 import {
   missionsNotValidatedByAllWorkers,
   missionValidatedByAdmin,
@@ -225,9 +228,11 @@ export function MissionDetails({
   if (missionLoadError)
     return <Typography color="error">{missionLoadError}</Typography>;
   if (!mission) return null;
+
   const readOnlyMission =
     missionValidatedByAdmin(mission) ||
-    missionsNotValidatedByAllWorkers(mission);
+    (missionsNotValidatedByAllWorkers(mission) &&
+      !missionCreatedByAdmin(mission, adminStore.employments));
 
   const missionCompany = adminStore.companies.find(
     c => c.id === mission.companyId


### PR DESCRIPTION
Mission created by admin should be editable even when not all workers have validated them.