### PR TITLE
Make break editables again

### DIFF
--- a/web/pwa/components/ActivityList.js
+++ b/web/pwa/components/ActivityList.js
@@ -110,7 +110,7 @@ function ActivityItem({
             : { color: "primary" }
         }
       />
-      {editActivityEvent && activity.id && (
+      {editActivityEvent && (
         <ListItemSecondaryAction>
           <IconButton
             edge="end"


### PR DESCRIPTION
PR qui corrige la régression suivante dans la PWA : les pauses ne sont plus modifiables alors qu'elles l'étaient avant.

@rtaieb J'en ai profité pour corriger la méthode `convertBreakIntoActivityOperations` que tu utilises pour calculer les modifications sur les autres activtés dans ton ticket actuel => la modification de la dernière activité fonctionne correctement