### PR TITLE
Better layout for employment validation

### DIFF
--- a/web/common/EmploymentInfoCard.js
+++ b/web/common/EmploymentInfoCard.js
@@ -38,6 +38,9 @@ const useStyles = makeStyles(theme => ({
   },
   ended: {
     opacity: 0.5
+  },
+  employmentDetails: {
+    display: "block"
   }
 }));
 
@@ -138,7 +141,7 @@ export function EmploymentInfoCard({
           )}
         </Grid>
       </AccordionSummary>
-      <AccordionDetails>
+      <AccordionDetails className={classes.employmentDetails}>
         <Grid container wrap="wrap" spacing={spacing}>
           <Grid item>
             <InfoItem name="SIREN" value={employment.company.siren} />


### PR DESCRIPTION
Lorsqu'un employé devait valider son rattachement, l'affichage était cassé, particulièrement sur téléphone.
![image](https://user-images.githubusercontent.com/35224301/153837554-8df4a768-6aa8-49d7-b975-ea55fb7b55d4.png)

Cette PR corrige cet affichage : 
![image](https://user-images.githubusercontent.com/35224301/153837814-73747665-23ee-4e99-adc9-1433415438a6.png)

