### PR TITLE
Add explicit error message when trying to record an activity in the future

### DIFF
--- a/common/utils/errors.js
+++ b/common/utils/errors.js
@@ -178,10 +178,11 @@ export function defaultFormatGraphQLApiError(graphQLError, store) {
       case "ACTIVITY_TIME_IN_FUTURE":
         return `La date de ${
           graphQLError.extensions.eventName === "Start" ? "début" : "fin"
-        } de l'activité renseignée est ${((graphQLError.extensions.eventTime -
-          graphQLError.extensions.receptionTime) /
-          60) >>
-          0} minutes dans le futur. Veuillez vérifier l'heure de votre téléphone.`;
+        } de l'activité renseignée est ${Math.floor(
+          (graphQLError.extensions.eventTime -
+            graphQLError.extensions.receptionTime) /
+            60
+        )} minutes dans le futur. Veuillez vérifier l'heure de votre téléphone.`;
       default:
         return null;
     }

--- a/common/utils/errors.js
+++ b/common/utils/errors.js
@@ -175,6 +175,13 @@ export function defaultFormatGraphQLApiError(graphQLError, store) {
         return "Un mail d'activation a récemment été envoyé. Vérifiez votre boîte mail.";
       case "MAILJET_ERROR":
         return "Erreur lors de l'envoi du mail. Veuillez réessayer plus tard.";
+      case "ACTIVITY_TIME_IN_FUTURE":
+        return `La date de ${
+          graphQLError.extensions.eventName === "Start" ? "début" : "fin"
+        } de l'activité renseignée est ${((graphQLError.extensions.eventTime -
+          graphQLError.extensions.receptionTime) /
+          60) >>
+          0} minutes dans le futur. Veuillez vérifier l'heure de votre téléphone.`;
       default:
         return null;
     }


### PR DESCRIPTION
https://trello.com/c/qaYdRBQe/571-message-derreur-dans-le-cas-dun-enregistrement-dactivit%C3%A9-dans-le-futur

Si l'heure du téléphone d'un utilisateur et sen avance, il ne pourra pas renseigner son temps dans Mobilic car on considèrera qu'il tente d'enregistrer du temps de travail dans le futur.

Avant cette PR, il n'y avait pas de message explicite expliquant à l'utilisateur d'où vient le problème.

La PR du back est ici : https://github.com/MTES-MCT/mobilic-api/pull/56