### PR TITLE
Prevent displaying an invitation twice when accepting it via email

### DIFF
--- a/web/home/RedeemInvite.js
+++ b/web/home/RedeemInvite.js
@@ -60,10 +60,12 @@ export function RedeemInvite() {
           { context: { nonPublicApi: true } }
         );
         if (!shouldLoadUser) {
-          await store.createEntityObject(
-            apiResponse.data.signUp.redeemInvite,
-            "employments"
-          );
+          await store.updateEntityObject({
+            objectId: employment.data.employment.id,
+            entity: "employments",
+            update: apiResponse.data.signUp.redeemInvite,
+            createOrReplace: true
+          });
           store.batchUpdate();
         } else await store.updateUserIdAndInfo();
         await broadCastChannel.postMessage("update");


### PR DESCRIPTION
When accepting an invitation via the email link, we should update it in the store, and not create a new one.

https://trello.com/c/E4ifs3x8/584-invitation-en-double-apr%C3%A8s-acceptation-dans-le-mail