### PR TITLE
Change number of working days retrieved during a user control

### DIFF
--- a/web/control/UserRead.js
+++ b/web/control/UserRead.js
@@ -27,6 +27,7 @@ import { UserReadHistory } from "./components/UserReadHistory";
 import { TextWithBadge } from "../common/TextWithBadge";
 import { UserReadAlerts } from "./components/UserReadAlerts";
 import { computeAlerts } from "common/utils/regulation/computeAlerts";
+import { getDaysBetweenTwoDates } from "common/utils/time";
 
 function getTabs(alertsNumber) {
   return [
@@ -73,6 +74,7 @@ export function UserRead() {
   const [vehicles, setVehicles] = React.useState(null);
   const [periodOnFocus, setPeriodOnFocus] = React.useState(null);
   const [groupedAlerts, setGroupedAlerts] = React.useState([]);
+  const [workingDays, setWorkingDays] = React.useState(new Set([]));
 
   const [error, setError] = React.useState("");
 
@@ -146,6 +148,15 @@ export function UserRead() {
           ).filter(m => m.activities.length > 0);
 
           setMissions(missions_);
+
+          const userWorkingDays = new Set([]);
+          missions_.forEach(mission =>
+            getDaysBetweenTwoDates(
+              mission.startTime,
+              mission.endTime || tokenInfo.creationDay
+            ).forEach(day => userWorkingDays.add(day))
+          );
+          setWorkingDays(userWorkingDays);
           setGroupedAlerts(
             computeAlerts(
               missions_,
@@ -202,6 +213,7 @@ export function UserRead() {
         vehicles={vehicles}
         periodOnFocus={periodOnFocus}
         setPeriodOnFocus={setPeriodOnFocus}
+        workingDaysNumber={workingDays.size}
       />
     ) : null
   ];

--- a/web/control/components/UserReadInfo.js
+++ b/web/control/components/UserReadInfo.js
@@ -43,6 +43,7 @@ export function UserReadInfo({
   tokenInfo,
   controlTime,
   alertNumber,
+  workingDaysNumber,
   setTab
 }) {
   const alerts = useSnackbarAlerts();
@@ -83,7 +84,7 @@ export function UserReadInfo({
           </Grid>
         ))}
       </Grid>
-      <Typography variant="h5">Historique récent (60 jours)</Typography>
+      <Typography variant="h5">Historique récent (28 jours)</Typography>
       <Grid container wrap="wrap" spacing={2}>
         <Grid item>
           <InfoItem
@@ -112,7 +113,9 @@ export function UserReadInfo({
         className={classes.linkButtons}
       >
         <Grid item xs={6} style={{ textAlign: "center" }}>
-          <Typography>Nombre de journées enregistrées : 28</Typography>
+          <Typography>
+            Nombre de journées enregistrées : {workingDaysNumber}
+          </Typography>
           <Link
             color="primary"
             variant="body1"


### PR DESCRIPTION
https://trello.com/c/TykoFhYU/627-r%C3%A9duire-lacc%C3%A8s-de-lhistorique-salari%C3%A9-contr%C3%B4l%C3%A9-en-bord-de-route-%C3%A0-28-jours-0

PR back : https://github.com/MTES-MCT/mobilic-api/pull/70

J'en ai profité pour corriger le nb de jours travaillés présentés sur la page d'info d'un contrôle, qui était jusqu'à présent en dur :sweat_smile: 