### PR TITLE
Add specific error message when terminating employment

### DIFF
--- a/common/utils/errors.js
+++ b/common/utils/errors.js
@@ -107,6 +107,10 @@ export function defaultFormatGraphQLApiError(graphQLError, store) {
         return "L'adresse email est déjà utilisée.";
       case "FC_USER_ALREADY_REGISTERED":
         return "L'utilisateur est déjà inscrit sur Mobilic.";
+      case "ACTIVITY_EXIST_AFTER_EMPLOYMENT_END_DATE":
+        return "Impossible de terminer à cette date. Vérifiez que le salarié n'a pas d'activités après la date choisie.";
+      case "EMPLOYMENT_ALREADY_TERMINATED":
+        return "Opération impossible, une date de fin a déjà été renseignée pour ce rattachement.";
       case "OVERLAPPING_MISSIONS":
         return `Chevauchement avec la mission ${
           graphQLError.extensions.conflictingMission.name

--- a/common/utils/errors.js
+++ b/common/utils/errors.js
@@ -108,7 +108,7 @@ export function defaultFormatGraphQLApiError(graphQLError, store) {
       case "FC_USER_ALREADY_REGISTERED":
         return "L'utilisateur est déjà inscrit sur Mobilic.";
       case "ACTIVITY_EXIST_AFTER_EMPLOYMENT_END_DATE":
-        return "Impossible de terminer à cette date. Vérifiez que le salarié n'a pas d'activités après la date choisie.";
+        return "Détachement impossible à cette date. Vérifiez que le salarié n'a pas d'activités en cours ou d'activités après la date choisie.";
       case "EMPLOYMENT_ALREADY_TERMINATED":
         return "Opération impossible, une date de fin a déjà été renseignée pour ce rattachement.";
       case "OVERLAPPING_MISSIONS":

--- a/web/admin/components/TerminateEmployment.js
+++ b/web/admin/components/TerminateEmployment.js
@@ -49,7 +49,7 @@ export default function TerminateEmployment({
             "terminate-employment",
             gqlError => {
               if (graphQLErrorMatchesCode(gqlError, "INVALID_INPUTS")) {
-                return "Impossible de terminer à cette date. Vérifiez que le rattachement n'est pas déjà terminé et que le salarié n'a pas d'activités après la date choisie.";
+                return "Impossible de terminer à cette date. La date de fin du rattachement doit être postérieure à la date de début.";
               }
             }
           );


### PR DESCRIPTION
https://trello.com/c/T48Pkk5G/669-modifier-le-message-derreur-en-cas-de-non-succ%C3%A8s-du-d%C3%A9tachement-dun-salari%C3%A9

Message spécifique lorsqu'on veut terminer un rattachement dans le cas où :
- Le rattachement est déjà terminé
- Il existe des activités postérieures à la date de fin demandée

PR back : https://github.com/MTES-MCT/mobilic-api/pull/76