### PR TITLE
Add the ability to see activities for user that have been deattached

### DIFF
--- a/common/utils/apiQueries.js
+++ b/common/utils/apiQueries.js
@@ -360,7 +360,7 @@ export const ADMIN_COMPANIES_QUERY = gql`
         id
         name
         ...CompanySettings
-        users {
+        users(fromDate: $activityAfter) {
           id
           firstName
           lastName
@@ -467,6 +467,11 @@ export const ADMIN_WORK_DAYS_QUERY = gql`
     user(id: $id) {
       adminedCompanies(companyIds: $companyIds) {
         id
+        users(fromDate: $activityAfter) {
+          id
+          firstName
+          lastName
+        }
         workDays(fromDate: $activityAfter, untilDate: $activityBefore) {
           ...WorkDayData
         }

--- a/web/admin/panels/Activities.js
+++ b/web/admin/panels/Activities.js
@@ -99,6 +99,7 @@ const onMinDateChange = debounce(
     companyId,
     setLoading,
     addWorkDays,
+    addUsers,
     api,
     alerts
   ) => {
@@ -112,6 +113,7 @@ const onMinDateChange = debounce(
           companyIds: [companyId]
         });
         addWorkDays(companiesPayload.data.user.adminedCompanies, newMinDate);
+        addUsers(companiesPayload.data.user.adminedCompanies);
       }, "load-work-days");
       setLoading(false);
     }
@@ -181,7 +183,11 @@ function ActivitiesPanel() {
           type: ADMIN_ACTIONS.addWorkDays,
           payload: { companiesPayload, minDate: newMinDate }
         }),
-
+      companiesPayload =>
+        adminStore.dispatch({
+          type: ADMIN_ACTIONS.addUsers,
+          payload: { companiesPayload }
+        }),
       api,
       alerts
     );

--- a/web/admin/store/reducers/root.js
+++ b/web/admin/store/reducers/root.js
@@ -18,6 +18,7 @@ import {
 } from "./crud";
 import { updateSettingsReducer } from "./settings";
 import { updateActivitiesFiltersReducer } from "./activitiesFilters";
+import { addUsersReducer } from "./users";
 
 export const ADMIN_ACTIONS = {
   createOrSyncActivity: createOrSyncActivityReducer,
@@ -33,7 +34,8 @@ export const ADMIN_ACTIONS = {
   updateCompanyDetails: updateCompanyDetailsReducer,
   updateCompaniesList: updateCompaniesListReducer,
   updateCompanyId: updateCompanyIdReducer,
-  updateActivitiesFilters: updateActivitiesFiltersReducer
+  updateActivitiesFilters: updateActivitiesFiltersReducer,
+  addUsers: addUsersReducer
 };
 
 const ADMIN_REDUCERS = {};

--- a/web/admin/store/reducers/users.js
+++ b/web/admin/store/reducers/users.js
@@ -1,0 +1,15 @@
+import flatMap from "lodash/flatMap";
+import uniqBy from "lodash/uniqBy";
+
+export function addUsersReducer(state, { companiesPayload }) {
+  const users = flatMap(
+    companiesPayload.map(c => c.users.map(u => ({ ...u, companyId: c.id })))
+  );
+  const newUsers = uniqBy(users, u => u.id);
+
+  return {
+    ...state,
+    users: newUsers,
+    activitiesFilters: { ...state.activitiesFilters, users: newUsers }
+  };
+}


### PR DESCRIPTION
https://trello.com/c/lU4UaLxt/675-etq-gestionnaire-je-ne-vois-plus-les-activit%C3%A9s-des-salari%C3%A9s-pour-qui-jai-mis-fin-au-rattachement

Il est désormais possible de voir les activités des salariés qui ne sont plus rattachés à la société.

PR Back : https://github.com/MTES-MCT/mobilic-api/pull/79