### PR TITLE
Fix/blank on update

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -647,6 +647,7 @@ module.exports = function(webpackEnv) {
           exclude: [
             /\.map$/,
             /asset-manifest\.json$/,
+            /index.html/,
             /\.LICENSE$/,
             /hero.*\.jpg$/,
             /.*partner-logos.*/,

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -644,10 +644,10 @@ module.exports = function(webpackEnv) {
           additionalManifestEntries: [{ url: "/favicon.svg", revision: "1" }],
           clientsClaim: true,
           skipWaiting: true,
+          maximumFileSizeToCacheInBytes: 10 * 1024 * 1024,
           exclude: [
             /\.map$/,
             /asset-manifest\.json$/,
-            /index.html/,
             /\.LICENSE$/,
             /hero.*\.jpg$/,
             /.*partner-logos.*/,


### PR DESCRIPTION
https://trello.com/c/XedEphz8/684-obligation-de-rafra%C3%AEchir-la-page-apr%C3%A8s-une-mise-%C3%A0-jour-applicative

Le problème vient du fait que lorsqu'on va par exemple sur https://staging.mobilic.beta.gouv.fr/, on obtient d'abord le fichier index.html du serviceWorker, qui référence notamment les js et css.

Dans le cas où on a une mise à jour du front, le nom de ces fichiers changent, et lorsque le navigateur tente de charger le fichier js du DSFR, il n'est pas trouvé et arrête donc tout traitement.
Il n'y avait pas de problème avant car les fichiers JS utilsés étaient moins volumineux et donc stockés dans le service worker, donc toujours accessible.

Pour contourner le problème, j'ai augmenté la taille des fichiers que l'on peut stocker dans le service worker.

Une meilleure solution aurait été d'adopter une stratégie de chargement "network first" pour le index.html mais je n'ai pas réussi.
Pour info si on exclut le index.html du service worker le mode offline ne fonctionne plus.