### PR TITLE
Remove night work definition

### DIFF
--- a/web/landing/ResourcePage/RegulationDefinition.js
+++ b/web/landing/ResourcePage/RegulationDefinition.js
@@ -16,19 +16,6 @@ export const DEFINITIONS = {
       </span>
     )
   },
-  nightWork: {
-    name: "Travail de nuit",
-    content: (
-      <span>
-        entre <Emphasis>22 heures et 5 heures</Emphasis> (
-        <RegulationLegalArticleLink
-          article={LEGAL_ARTICLES.nightWork}
-          shortLabel
-        />
-        ).
-      </span>
-    )
-  },
   nightWorker: {
     name: "Travailleur de nuit",
     content: (

--- a/web/landing/ResourcePage/RegulationRules.js
+++ b/web/landing/ResourcePage/RegulationRules.js
@@ -42,11 +42,7 @@ export const REGULATION_RULES = {
         ).
       </span>
     ),
-    definitions: [
-      DEFINITIONS.amplitude,
-      DEFINITIONS.nightWork,
-      DEFINITIONS.nightWorker
-    ],
+    definitions: [DEFINITIONS.amplitude, DEFINITIONS.nightWorker],
     articles: [
       LEGAL_ARTICLES.dailyWork,
       LEGAL_ARTICLES.dailyWorkDuringNight,


### PR DESCRIPTION
https://trello.com/c/qdJbd962/672-correctif-des-heures-consid%C3%A9r%C3%A9es-comme-travail-de-nuit-pour-les-primes

Retrait de la définition des heures de nuit.

PR Back : https://github.com/MTES-MCT/mobilic-api/pull/87