### PR TITLE
Add call to cancel mission endpoint

### DIFF
--- a/common/utils/apiQueries.js
+++ b/common/utils/apiQueries.js
@@ -828,6 +828,29 @@ export const CANCEL_ACTIVITY_MUTATION = gql`
     }
   }
 `;
+export const CANCEL_MISSION_MUTATION = gql`
+  mutation cancelMission($missionId: Int!, $userId: Int!) {
+    activities {
+      cancelMission(missionId: $missionId, userId: $userId) {
+        activities {
+          id
+          type
+          missionId
+          startTime
+          endTime
+          userId
+          submitterId
+          lastSubmitterId
+          user {
+            id
+            firstName
+            lastName
+          }
+        }
+      }
+    }
+  }
+`;
 export const EDIT_ACTIVITY_MUTATION = gql`
   mutation editActivity(
     $activityId: Int!

--- a/web/admin/components/MissionDetails/MissionDetails.js
+++ b/web/admin/components/MissionDetails/MissionDetails.js
@@ -517,7 +517,13 @@ export function MissionDetails({
                             allowSupportActivity,
                             nullableEndTime: false,
                             forcedUser: e.user,
-                            displayWarningMessage: false
+                            displayWarningMessage: false,
+                            handleCancelMission: async () => {
+                              await missionActions.cancelMission({
+                                user: e.user
+                              });
+                              handleClose();
+                            }
                           })
                       : null
                   }

--- a/web/admin/utils/missionActions.js
+++ b/web/admin/utils/missionActions.js
@@ -3,6 +3,7 @@ import {
   buildLogLocationPayloadFromAddress,
   BULK_ACTIVITY_QUERY,
   CANCEL_COMMENT_MUTATION,
+  CANCEL_MISSION_MUTATION,
   CHANGE_MISSION_NAME_MUTATION,
   LOG_COMMENT_MUTATION,
   LOG_LOCATION_MUTATION,
@@ -208,6 +209,20 @@ async function validateMission(api, mission, adminStore, userToValidate) {
   mission.validations.push(validation);
 }
 
+async function cancelMission(api, mission, adminStore, args) {
+  const user = args.user;
+  const apiResponse = await api.graphQlMutate(CANCEL_MISSION_MUTATION, {
+    missionId: mission.id,
+    userId: user.id
+  });
+  adminStore.dispatch({
+    type: ADMIN_ACTIONS.resetVirtual
+  });
+  mission.activities = [
+    ...apiResponse.data.activities.cancelMission.activities
+  ];
+}
+
 async function deleteComment(api, mission, adminStore, comment) {
   await api.graphQlMutate(CANCEL_COMMENT_MUTATION, {
     commentId: comment.id
@@ -316,6 +331,7 @@ export function useMissionActions(
     createExpenditure: missionActionsDecorator(createExpenditure),
     cancelExpenditure: missionActionsDecorator(cancelExpenditure),
     validateMission: missionActionsDecorator(validateMission),
+    cancelMission: missionActionsDecorator(cancelMission),
     createComment: missionActionsDecorator(createComment, false),
     deleteComment: missionActionsDecorator(deleteComment, false),
     changeName: missionActionsDecorator(changeName),

--- a/web/pwa/components/ActivityRevision/ActivityRevision.js
+++ b/web/pwa/components/ActivityRevision/ActivityRevision.js
@@ -495,7 +495,8 @@ export default function ActivityRevisionOrCreationModal({
                   otherUserActivities.length === 0) && (
                   <Alert severity="warning">
                     En supprimant la seule activité d'une mission, vous
-                    annulerez la mission.
+                    annulerez la mission. Vous ne pourrez plus y apporter de
+                    modifications.
                   </Alert>
                 ),
                 cancelButtonLabel: "Annuler",


### PR DESCRIPTION
https://trello.com/c/464VvOT9/738-etq-gestionnaire-je-veux-pouvoir-supprimer-une-mission

Lorsqu'un admin supprime une activité d'un utilisateur, et qu'il n'y a pas d'autres activités pour cet utilisateur dans la mission, on appelle un nouveau endpoint pour annuler toutes les activités de l'utilisateur pour la mission donnée, sans attendre le clic sur le bouton "valider les saisies"

PR Back : https://github.com/MTES-MCT/mobilic-api/pull/94