### PR TITLE
Feat/controller scan

### DIFF
--- a/common/assets/styles/root.scss
+++ b/common/assets/styles/root.scss
@@ -266,3 +266,30 @@
 .MuiTab-root:active {
   --active-tint: inherit;
 }
+
+.camera-box {
+  --b: 8px;   /* thickness of the border */
+  --c: #3284ff;   /* color of the border */
+  --w: 60px;  /* width of border */
+  --r: 32px;  /* radius */
+  z-index: 2000;
+
+  padding: var(--b); /* space for the border */
+
+  position:relative;
+}
+.camera-box::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: var(--c,red);
+  padding: var(--b);
+  border-radius: var(--r);
+  -webkit-mask:
+          linear-gradient(  0deg,#000 calc(2*var(--b)),#0000 0) 50% var(--b)/calc(100% - 2*var(--w)) 100% repeat-y,
+          linear-gradient(-90deg,#000 calc(2*var(--b)),#0000 0) var(--b) 50%/100% calc(100% - 2*var(--w)) repeat-x,
+          linear-gradient(#000 0 0) content-box,
+          linear-gradient(#000 0 0);
+  -webkit-mask-composite: destination-out;
+  mask-composite: exclude;
+}

--- a/common/assets/styles/root.scss
+++ b/common/assets/styles/root.scss
@@ -268,13 +268,13 @@
 }
 
 .camera-box {
-  --b: 8px;   /* thickness of the border */
-  --c: #3284ff;   /* color of the border */
-  --w: 60px;  /* width of border */
-  --r: 32px;  /* radius */
+  --border-thickness: 8px;
+  --border-color: #3284ff;   /* color of the border */
+  --border-width: 60px;  /* width of border */
+  --border-radius: 32px;  /* radius */
   z-index: 2000;
 
-  padding: var(--b); /* space for the border */
+  padding: var(--border-thickness); /* space for the border */
 
   position:relative;
 }
@@ -282,12 +282,12 @@
   content: "";
   position: absolute;
   inset: 0;
-  background: var(--c,red);
-  padding: var(--b);
-  border-radius: var(--r);
+  background: var(--border-color,red);
+  padding: var(--border-thickness);
+  border-radius: var(--border-radius);
   -webkit-mask:
-          linear-gradient(  0deg,#000 calc(2*var(--b)),#0000 0) 50% var(--b)/calc(100% - 2*var(--w)) 100% repeat-y,
-          linear-gradient(-90deg,#000 calc(2*var(--b)),#0000 0) var(--b) 50%/100% calc(100% - 2*var(--w)) repeat-x,
+          linear-gradient(  0deg,#000 calc(2*var(--border-thickness)),#0000 0) 50% var(--border-thickness)/calc(100% - 2*var(--border-width)) 100% repeat-y,
+          linear-gradient(-90deg,#000 calc(2*var(--border-thickness)),#0000 0) var(--border-thickness) 50%/100% calc(100% - 2*var(--border-width)) repeat-x,
           linear-gradient(#000 0 0) content-box,
           linear-gradient(#000 0 0);
   -webkit-mask-composite: destination-out;

--- a/common/utils/apiQueries.js
+++ b/common/utils/apiQueries.js
@@ -1299,6 +1299,15 @@ export const CHANGE_MISSION_NAME_MUTATION = gql`
   }
 `;
 
+export const CONTROLLER_SCAN_CODE = gql`
+  mutation controllerScanCode($jwtToken: String!) {
+    controllerScanCode(jwtToken: $jwtToken) {
+      id
+      validFrom
+    }
+  }
+`;
+
 export function buildLogLocationPayloadFromAddress(
   address,
   missionId,

--- a/common/utils/apiQueries.js
+++ b/common/utils/apiQueries.js
@@ -1303,7 +1303,7 @@ export const CONTROLLER_SCAN_CODE = gql`
   mutation controllerScanCode($jwtToken: String!) {
     controllerScanCode(jwtToken: $jwtToken) {
       id
-      validFrom
+      qrCodeGenerationTime
     }
   }
 `;

--- a/common/utils/errors.js
+++ b/common/utils/errors.js
@@ -191,6 +191,8 @@ export function defaultFormatGraphQLApiError(graphQLError, store) {
         return "La modification de votre rôle ne peut être effectuée que par un autre gestionnaire.";
       case "USER_SELF_TERMINATE_EMPLOYMENT":
         return "L'action de mettre fin à votre rattachement ne peut être effectuée que par un autre gestionnaire.";
+      case "INVALID_CONTROL_TOKEN":
+        return "Le QR Code n'a pas été reconnu par Mobilic.";
       default:
         return null;
     }

--- a/common/utils/time.js
+++ b/common/utils/time.js
@@ -129,6 +129,12 @@ export function textualPrettyFormatDay(unixTimestamp, withYear = false) {
   return withYear ? `${baseString} ${date.getFullYear()}` : baseString;
 }
 
+export function prettyFormatDayHour(unixTimestamp) {
+  const date = new Date(unixTimestamp * 1000);
+  return `${date.getDate()}/${date.getMonth() +
+    1} à ${date.getHours()}:${date.getMinutes()}`;
+}
+
 export function textualPrettyFormatWeek(startOfWeek) {
   const date = new Date(startOfWeek * 1000);
   return `Semaine du ${_localFormatDate(date)} au ${_localFormatDate(

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "react-dropzone": "^11.3.1",
     "react-error-boundary": "^3.1.3",
     "react-minimal-pie-chart": "^8.2.0",
+    "react-qr-reader": "^3.0.0-beta-1",
     "react-redux": "^7.2.0",
     "react-router-dom": "^5.1.2",
     "react-virtualized": "^9.22.2",

--- a/web/common/routes.js
+++ b/web/common/routes.js
@@ -29,6 +29,7 @@ import groupBy from "lodash/groupBy";
 import LoginController from "../login/login-controller";
 import { AgentConnectCallback } from "../signup/AgentConnectCallback";
 import { ControllerHome } from "../controller/components/home/ControllerHome";
+import { ControllerScanQRCode } from "../controller/components/scanQRCode/ControllerScanQRCode";
 
 function UserReadRedirect() {
   const { token } = useParams();
@@ -222,9 +223,18 @@ export const ROUTES = [
     path: CONTROLLER_ROUTE_PREFIX + "/history",
     label: "Historique des contrôles",
     accessible: ({ controllerInfo }) => {
-      return controllerInfo?.id;
+      return !!controllerInfo?.id;
     },
     component: ControllerHome,
+    menuItemFilter: () => false
+  },
+  {
+    path: CONTROLLER_ROUTE_PREFIX + "/scan",
+    label: "Scan QR Code",
+    accessible: ({ controllerInfo }) => {
+      return !!controllerInfo?.id;
+    },
+    component: ControllerScanQRCode,
     menuItemFilter: () => false
   },
   {

--- a/web/common/routes.js
+++ b/web/common/routes.js
@@ -30,6 +30,7 @@ import LoginController from "../login/login-controller";
 import { AgentConnectCallback } from "../signup/AgentConnectCallback";
 import { ControllerHome } from "../controller/components/home/ControllerHome";
 import { ControllerScanQRCode } from "../controller/components/scanQRCode/ControllerScanQRCode";
+import { ControllerQRCodeNotRecognized } from "../controller/components/scanQRCode/ControllerQRCodeNotRecognized";
 
 function UserReadRedirect() {
   const { token } = useParams();
@@ -235,6 +236,15 @@ export const ROUTES = [
       return !!controllerInfo?.id;
     },
     component: ControllerScanQRCode,
+    menuItemFilter: () => false
+  },
+  {
+    path: CONTROLLER_ROUTE_PREFIX + "/scan_error",
+    label: "Erreur de Scan QR Code",
+    accessible: ({ controllerInfo }) => {
+      return !!controllerInfo?.id;
+    },
+    component: ControllerQRCodeNotRecognized,
     menuItemFilter: () => false
   },
   {

--- a/web/control/UserReadQRCode.js
+++ b/web/control/UserReadQRCode.js
@@ -42,10 +42,11 @@ export default function UserReadQRCodeModal({ open, handleClose }) {
     try {
       const json = await api.jsonHttpQuery(HTTP_QUERIES.generateUserReadToken);
       const token = json.token;
+      const controlToken = json.controlToken;
       setLink(
         `${
           window.location.origin
-        }/control/user-history?token=${token}&ts=${now()}`
+        }/control/user-history?token=${token}&ts=${now()}&controlToken=${controlToken}`
       );
     } catch (err) {
       setError(formatApiError(err));

--- a/web/controller/components/home/ControllerHome.js
+++ b/web/controller/components/home/ControllerHome.js
@@ -52,7 +52,7 @@ export function ControllerHome() {
       <Grid container direction="row" alignItems="stretch" spacing={3}>
         <Grid item xs={12} sm={4}>
           <ControllerHomeCard
-            text={"QR code Mobilic présenté"}
+            text={"QR Code Mobilic présenté"}
             icon={"fr-icon-qr-code-line fr-icon--lg"}
             link={CONTROLLER_ROUTE_PREFIX + "/scan"}
           />

--- a/web/controller/components/home/ControllerHome.js
+++ b/web/controller/components/home/ControllerHome.js
@@ -6,6 +6,7 @@ import Container from "@mui/material/Container";
 import { ControllerHomeCard } from "./ControllerHomeCard";
 import Grid from "@mui/material/Grid";
 import classNames from "classnames";
+import { CONTROLLER_ROUTE_PREFIX } from "../../../common/routes";
 
 const useStyles = makeStyles(theme => ({
   container: {
@@ -53,6 +54,7 @@ export function ControllerHome() {
           <ControllerHomeCard
             text={"QR code Mobilic présenté"}
             icon={"fr-icon-qr-code-line fr-icon--lg"}
+            link={CONTROLLER_ROUTE_PREFIX + "/scan"}
           />
         </Grid>
         <Grid item xs={12} sm={4}>

--- a/web/controller/components/home/ControllerHomeCard.js
+++ b/web/controller/components/home/ControllerHomeCard.js
@@ -37,7 +37,7 @@ export function ControllerHomeCard({ text, icon, link, onClick }) {
   let buttonActionProps = { onClick };
   let ButtonComponent = ButtonBase;
   if (link) {
-    buttonActionProps = { href: link, target: "_blank" };
+    buttonActionProps = { to: link };
     ButtonComponent = LinkButton;
   }
 

--- a/web/controller/components/scanQRCode/ControllerQRCodeNotRecognized.js
+++ b/web/controller/components/scanQRCode/ControllerQRCodeNotRecognized.js
@@ -1,0 +1,67 @@
+import React from "react";
+import { ControllerHeader } from "../header/ControllerHeader";
+import { makeStyles } from "@mui/styles";
+import Container from "@mui/material/Container";
+import classNames from "classnames";
+import { Alert } from "@mui/material";
+import Link from "react-router-dom/es/Link";
+import { CONTROLLER_ROUTE_PREFIX } from "../../../common/routes";
+import Typography from "@mui/material/Typography";
+
+const useStyles = makeStyles(theme => ({
+  container: {
+    paddingTop: theme.spacing(3),
+    paddingBottom: theme.spacing(7),
+    paddingLeft: theme.spacing(2),
+    paddingRight: theme.spacing(2),
+    margin: 0,
+    textAlign: "left"
+  },
+  linkScan: {
+    textAlign: "left"
+  },
+  title: {
+    textAlign: "center",
+    marginTop: theme.spacing(3)
+  },
+  whiteSection: {
+    backgroundColor: theme.palette.background.paper
+  },
+  warningMessage: {
+    marginTop: theme.spacing(3)
+  }
+}));
+export function ControllerQRCodeNotRecognized() {
+  const classes = useStyles();
+
+  return [
+    <ControllerHeader key={0} />,
+    <Container
+      key={20}
+      className={`${classes.container} ${classes.whiteSection}`}
+      maxWidth="xl"
+    >
+      <Link
+        className={classNames(
+          classes.linkScan,
+          "fr-link",
+          "fr-fi-arrow-left-line",
+          "fr-link--icon-left"
+        )}
+        to={CONTROLLER_ROUTE_PREFIX + "/scan"}
+      >
+        Scannez un QR Code
+      </Link>
+      <h3 className={classes.title}>QR Code non reconnu</h3>
+      <Typography>
+        Nous n'avons pas pu vérifier la validité de ce QR Code. Il se peut que
+        le QR Code scanné{" "}
+        <b>provienne d'une application tierce non interfacée à Mobilic.</b>
+      </Typography>
+      <Alert severity="warning" className={classes.warningMessage}>
+        N'hésitez pas à nous remonter le nom de l'application utilisée par le
+        salarié, afin que nous contactions cet éditeur de logiciel.
+      </Alert>
+    </Container>
+  ];
+}

--- a/web/controller/components/scanQRCode/ControllerScanQRCode.js
+++ b/web/controller/components/scanQRCode/ControllerScanQRCode.js
@@ -11,11 +11,11 @@ import Link from "react-router-dom/es/Link";
 import { CONTROLLER_ROUTE_PREFIX } from "../../../common/routes";
 import { CONTROLLER_SCAN_CODE } from "common/utils/apiQueries";
 import { useApi } from "common/utils/api";
-import { formatApiError } from "common/utils/errors";
 import { useSnackbarAlerts } from "../../../common/Snackbar";
 import { prettyFormatDayHour } from "common/utils/time";
 import { useHistory } from "react-router-dom";
 import { useLoadingScreen } from "common/utils/loading";
+import Typography from "@mui/material/Typography";
 
 const useStyles = makeStyles(theme => ({
   container: {
@@ -31,7 +31,7 @@ const useStyles = makeStyles(theme => ({
   },
   titleScan: {
     textAlign: "center",
-    marginTop: theme.spacing(2)
+    marginTop: theme.spacing(3)
   },
   whiteSection: {
     backgroundColor: theme.palette.background.paper
@@ -46,10 +46,12 @@ const useStyles = makeStyles(theme => ({
     borderRadius: theme.spacing(3)
   },
   cameraGridContainer: {
-    marginTop: theme.spacing(6)
+    paddingRight: theme.spacing(3),
+    paddingLeft: theme.spacing(3),
+    marginTop: theme.spacing(2)
   },
   scanSeveralCodes: {
-    marginTop: theme.spacing(2)
+    marginTop: theme.spacing(3)
   }
 }));
 export function ControllerScanQRCode() {
@@ -83,14 +85,14 @@ export function ControllerScanQRCode() {
         const controlResponse = apiResponse.data.controllerScanCode;
         alerts.success(
           `Le contrôle ${controlResponse.id} du ${prettyFormatDayHour(
-            controlResponse.validFrom
+            controlResponse.qrCodeGenerationTime
           )} a été enregistré avec succès.`,
           "0",
           6000
         );
         history.push(CONTROLLER_ROUTE_PREFIX + "/home");
       } catch (err) {
-        alerts.error(formatApiError(err), scannedCode, 6000);
+        history.push(CONTROLLER_ROUTE_PREFIX + "/scan_error");
       }
     });
   };
@@ -114,6 +116,10 @@ export function ControllerScanQRCode() {
         Accueil
       </Link>
       <h3 className={classes.titleScan}>Scannez un QR Code Mobilic</h3>
+      <Typography>
+        Afin d'accéder à l'historique de 28 jours du salarié, positionnez son QR
+        Code dans le cadre.
+      </Typography>
       <Grid
         container
         justifyContent="center"

--- a/web/controller/components/scanQRCode/ControllerScanQRCode.js
+++ b/web/controller/components/scanQRCode/ControllerScanQRCode.js
@@ -148,11 +148,21 @@ export function ControllerScanQRCode() {
         </Grid>
       </Grid>
       <Alert severity="info" className={classes.scanSeveralCodes}>
-        Plusieurs personnes sont à bord du VUL ? Scannez un premier QR code (ex{" "}
+        Plusieurs personnes sont à bord du VUL ? Scannez un premier QR Code (ex{" "}
         : conducteur) puis procédez à un nouveau contrôle (ex : accompagnateur)
       </Alert>
-      <a className={classNames(classes.noQRCodeLink, "fr-link")} href="#">
-        Le salarié ne trouve pas son QR code ?
+      <a
+        className={classNames(
+          classes.noQRCodeLink,
+          "fr-link",
+          "fr-link--icon-right",
+          "fr-fi-external-link-line"
+        )}
+        target="_blank"
+        href="https://faq.mobilic.beta.gouv.fr/securite-et-confidentialite-des-donnees/modalites-de-controle"
+        rel="noopener noreferrer"
+      >
+        Le salarié ne trouve pas son QR Code ?
       </a>
     </Container>
   ];

--- a/web/controller/components/scanQRCode/ControllerScanQRCode.js
+++ b/web/controller/components/scanQRCode/ControllerScanQRCode.js
@@ -7,6 +7,8 @@ import { Alert } from "@mui/material";
 import { QrReader } from "react-qr-reader";
 import Grid from "@mui/material/Grid";
 import useTheme from "@mui/styles/useTheme";
+import Link from "react-router-dom/es/Link";
+import { CONTROLLER_ROUTE_PREFIX } from "../../../common/routes";
 
 const useStyles = makeStyles(theme => ({
   container: {
@@ -17,9 +19,12 @@ const useStyles = makeStyles(theme => ({
     margin: 0,
     textAlign: "left"
   },
+  linkHome: {
+    textAlign: "left"
+  },
   titleScan: {
     textAlign: "center",
-    marginTop: theme.spacing(3)
+    marginTop: theme.spacing(2)
   },
   whiteSection: {
     backgroundColor: theme.palette.background.paper
@@ -44,13 +49,22 @@ export function ControllerScanQRCode() {
   return [
     <ControllerHeader key={0} />,
     <Container
-      key={2}
+      key={20}
       className={`${classes.container} ${classes.whiteSection}`}
       maxWidth="xl"
     >
-      <h3 className={classes.titleScan} key={1}>
-        Scannez un QR Code Mobilic
-      </h3>
+      <Link
+        className={classNames(
+          classes.linkHome,
+          "fr-link",
+          "fr-fi-arrow-left-line",
+          "fr-link--icon-left"
+        )}
+        to={CONTROLLER_ROUTE_PREFIX + "/home"}
+      >
+        Accueil
+      </Link>
+      <h3 className={classes.titleScan}>Scannez un QR Code Mobilic</h3>
       <Alert severity="info" className={classes.missionTooLongWarning}>
         Plusieurs personnes sont à bord du VUL ? Scannez un premier QR code (ex{" "}
         : conducteur) puis procédez à un nouveau contrôle (ex : accompagnateur)

--- a/web/controller/components/scanQRCode/ControllerScanQRCode.js
+++ b/web/controller/components/scanQRCode/ControllerScanQRCode.js
@@ -40,6 +40,9 @@ const useStyles = makeStyles(theme => ({
   },
   cameraGridContainer: {
     marginTop: theme.spacing(6)
+  },
+  scanSeveralCodes: {
+    marginTop: theme.spacing(2)
   }
 }));
 export function ControllerScanQRCode() {
@@ -65,10 +68,6 @@ export function ControllerScanQRCode() {
         Accueil
       </Link>
       <h3 className={classes.titleScan}>Scannez un QR Code Mobilic</h3>
-      <Alert severity="info" className={classes.missionTooLongWarning}>
-        Plusieurs personnes sont à bord du VUL ? Scannez un premier QR code (ex{" "}
-        : conducteur) puis procédez à un nouveau contrôle (ex : accompagnateur)
-      </Alert>
       <Grid
         container
         justifyContent="center"
@@ -96,6 +95,10 @@ export function ControllerScanQRCode() {
           </div>
         </Grid>
       </Grid>
+      <Alert severity="info" className={classes.scanSeveralCodes}>
+        Plusieurs personnes sont à bord du VUL ? Scannez un premier QR code (ex{" "}
+        : conducteur) puis procédez à un nouveau contrôle (ex : accompagnateur)
+      </Alert>
       <a className={classNames(classes.noQRCodeLink, "fr-link")} href="#">
         Le salarié ne trouve pas son QR code ?
       </a>

--- a/web/controller/components/scanQRCode/ControllerScanQRCode.js
+++ b/web/controller/components/scanQRCode/ControllerScanQRCode.js
@@ -1,0 +1,90 @@
+import React from "react";
+import { ControllerHeader } from "../header/ControllerHeader";
+import { makeStyles } from "@mui/styles";
+import Container from "@mui/material/Container";
+import classNames from "classnames";
+import { Alert } from "@mui/material";
+import { QrReader } from "react-qr-reader";
+import Grid from "@mui/material/Grid";
+import useTheme from "@mui/styles/useTheme";
+
+const useStyles = makeStyles(theme => ({
+  container: {
+    paddingTop: theme.spacing(3),
+    paddingBottom: theme.spacing(7),
+    paddingLeft: theme.spacing(2),
+    paddingRight: theme.spacing(2),
+    margin: 0,
+    textAlign: "left"
+  },
+  titleScan: {
+    textAlign: "center",
+    marginTop: theme.spacing(3)
+  },
+  whiteSection: {
+    backgroundColor: theme.palette.background.paper
+  },
+  noQRCodeLink: {
+    marginTop: theme.spacing(4)
+  },
+  qrCodeScan: {
+    width: "100%"
+  },
+  videoContainerStyle: {
+    borderRadius: theme.spacing(3)
+  },
+  cameraGridContainer: {
+    marginTop: theme.spacing(6)
+  }
+}));
+export function ControllerScanQRCode() {
+  const classes = useStyles();
+  const theme = useTheme();
+
+  return [
+    <ControllerHeader key={0} />,
+    <Container
+      key={2}
+      className={`${classes.container} ${classes.whiteSection}`}
+      maxWidth="xl"
+    >
+      <h3 className={classes.titleScan} key={1}>
+        Scannez un QR Code Mobilic
+      </h3>
+      <Alert severity="info" className={classes.missionTooLongWarning}>
+        Plusieurs personnes sont à bord du VUL ? Scannez un premier QR code (ex{" "}
+        : conducteur) puis procédez à un nouveau contrôle (ex : accompagnateur)
+      </Alert>
+      <Grid
+        container
+        justifyContent="center"
+        className={classes.cameraGridContainer}
+      >
+        <Grid item xs={12} md={8} lg={4}>
+          <div className={"camera-box"}>
+            <QrReader
+              constraints={{ facingMode: "environment", aspectRatio: 1 }}
+              videoContainerStyle={{
+                borderRadius: theme.spacing(2),
+                zIndex: -1
+              }}
+              onResult={(result, error) => {
+                if (result) {
+                  console.log(result?.text);
+                }
+
+                if (error) {
+                  console.info(error);
+                }
+              }}
+              className={classes.qrCodeScan}
+            />
+          </div>
+        </Grid>
+      </Grid>
+      <a className={classNames(classes.noQRCodeLink, "fr-link")} href="#">
+        Le salarié ne trouve pas son QR code ?
+      </a>
+    </Container>
+  ];
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2996,6 +2996,27 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+"@zxing/browser@0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@zxing/browser/-/browser-0.0.7.tgz#5fa7680a867b660f48d3288fdf63e0174ad531c7"
+  integrity sha512-AepzMgDnD6EjxewqmXpHJsi4S3Gw9ilZJLIbTf6fWuWySEcHBodnGu3p7FWlgq1Sd5QyfPhTum5z3CBkkhMVng==
+  optionalDependencies:
+    "@zxing/text-encoding" "^0.9.0"
+
+"@zxing/library@^0.18.3":
+  version "0.18.6"
+  resolved "https://registry.yarnpkg.com/@zxing/library/-/library-0.18.6.tgz#717af8c6c1fd982865e21051afdd7b470ae6674c"
+  integrity sha512-bulZ9JHoLFd9W36pi+7e7DnEYNJhljYjZ1UTsKPOoLMU3qtC+REHITeCRNx40zTRJZx18W5TBRXt5pq2Uopjsw==
+  dependencies:
+    ts-custom-error "^3.0.0"
+  optionalDependencies:
+    "@zxing/text-encoding" "~0.9.0"
+
+"@zxing/text-encoding@^0.9.0", "@zxing/text-encoding@~0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@zxing/text-encoding/-/text-encoding-0.9.0.tgz#fb50ffabc6c7c66a0c96b4c03e3d9be74864b70b"
+  integrity sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==
+
 abab@^2.0.0:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.5.tgz#c0b678fb32d60fc1219c784d6a826fe385aeb79a"
@@ -12087,6 +12108,15 @@ react-property@2.0.0:
   resolved "https://registry.yarnpkg.com/react-property/-/react-property-2.0.0.tgz#2156ba9d85fa4741faf1918b38efc1eae3c6a136"
   integrity sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw==
 
+react-qr-reader@^3.0.0-beta-1:
+  version "3.0.0-beta-1"
+  resolved "https://registry.yarnpkg.com/react-qr-reader/-/react-qr-reader-3.0.0-beta-1.tgz#e04a20876409313439959d8e0ea6df3ba6e36d68"
+  integrity sha512-5HeFH9x/BlziRYQYGK2AeWS9WiKYZtGGMs9DXy3bcySTX3C9UJL9EwcPnWw8vlf7JP4FcrAlr1SnZ5nsWLQGyw==
+  dependencies:
+    "@zxing/browser" "0.0.7"
+    "@zxing/library" "^0.18.3"
+    rollup "^2.67.2"
+
 react-redux@^7.2.0, react-redux@^7.2.1:
   version "7.2.6"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.6.tgz#49633a24fe552b5f9caf58feb8a138936ddfe9aa"
@@ -12797,6 +12827,13 @@ rollup@^2.43.1:
   version "2.68.0"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.68.0.tgz#6ccabfd649447f8f21d62bf41662e5caece3bd66"
   integrity sha512-XrMKOYK7oQcTio4wyTz466mucnd8LzkiZLozZ4Rz0zQD+HeX4nUK4B8GrTX/2EvN2/vBF/i2WnaXboPxo0JylA==
+  optionalDependencies:
+    fsevents "~2.3.2"
+
+rollup@^2.67.2:
+  version "2.77.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.77.2.tgz#6b6075c55f9cc2040a5912e6e062151e42e2c4e3"
+  integrity sha512-m/4YzYgLcpMQbxX3NmAqDvwLATZzxt8bIegO78FZLl+lAgKJBd1DRAOeEiZcKOIOPjxE6ewHWHNgGEalFXuz1g==
   optionalDependencies:
     fsevents "~2.3.2"
 
@@ -14178,6 +14215,11 @@ tryer@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
   integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
+
+ts-custom-error@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ts-custom-error/-/ts-custom-error-3.2.0.tgz#ff8f80a3812bab9dc448536312da52dce1b720fb"
+  integrity sha512-cBvC2QjtvJ9JfWLvstVnI45Y46Y5dMxIaG1TDMGAD/R87hpvqFL+7LhvUDhnRCfOnx/xitollFWWvUKKKhbN0A==
 
 ts-invariant@^0.4.0:
   version "0.4.4"


### PR DESCRIPTION
https://trello.com/c/s0mV5r0P/648-contr%C3%B4le-avec-qr-code-mobilic

Ajout de l'écran pour scanner les QR code de contrôle.
J'ai laissé les QR code compatibles avec les anciennes versions (url complète) mais à terme on pourra uniquement mettre le JWT dans le QR code.

Note pour les tests : le QRcode doit être scanné dans une instance du site avec la même base url que celle qui a généré le QR code.

PR back : https://github.com/MTES-MCT/mobilic-api/pull/96