### PR TITLE
feat: error on activity creation before employment

### DIFF
--- a/common/utils/errors.js
+++ b/common/utils/errors.js
@@ -194,9 +194,9 @@ export function defaultFormatGraphQLApiError(graphQLError, store) {
       case "INVALID_CONTROL_TOKEN":
         return "Le QR Code n'a pas été reconnu par Mobilic.";
       case "ACTIVITY_BEFORE_EMPLOYMENT_EMPLOYEE":
-        return "Vous ne pouvez pas enregistrer des activités à une date antérieure à celle de votre rattachement.";
+        return "Vous ne pouvez pas enregistrer des activités en dehors de votre période de rattachement.";
       case "ACTIVITY_BEFORE_EMPLOYMENT_ADMIN":
-        return "Vous ne pouvez pas enregistrer des activités à une date antérieure à celle du rattachement du salarié sélectionné.";
+        return "Vous ne pouvez pas enregistrer des activités en dehors de la période de rattachement du salarié sélectionné.";
       default:
         return null;
     }

--- a/common/utils/errors.js
+++ b/common/utils/errors.js
@@ -193,6 +193,10 @@ export function defaultFormatGraphQLApiError(graphQLError, store) {
         return "L'action de mettre fin à votre rattachement ne peut être effectuée que par un autre gestionnaire.";
       case "INVALID_CONTROL_TOKEN":
         return "Le QR Code n'a pas été reconnu par Mobilic.";
+      case "ACTIVITY_BEFORE_EMPLOYMENT_EMPLOYEE":
+        return "Vous ne pouvez pas enregistrer des activités à une date antérieure à celle de votre rattachement.";
+      case "ACTIVITY_BEFORE_EMPLOYMENT_ADMIN":
+        return "Vous ne pouvez pas enregistrer des activités à une date antérieure à celle du rattachement du salarié sélectionné.";
       default:
         return null;
     }

--- a/common/utils/errors.js
+++ b/common/utils/errors.js
@@ -193,9 +193,9 @@ export function defaultFormatGraphQLApiError(graphQLError, store) {
         return "L'action de mettre fin à votre rattachement ne peut être effectuée que par un autre gestionnaire.";
       case "INVALID_CONTROL_TOKEN":
         return "Le QR Code n'a pas été reconnu par Mobilic.";
-      case "ACTIVITY_BEFORE_EMPLOYMENT_EMPLOYEE":
+      case "ACTIVITY_OUTSIDE_EMPLOYMENT_EMPLOYEE":
         return "Vous ne pouvez pas enregistrer des activités en dehors de votre période de rattachement.";
-      case "ACTIVITY_BEFORE_EMPLOYMENT_ADMIN":
+      case "ACTIVITY_OUTSIDE_EMPLOYMENT_ADMIN":
         return "Vous ne pouvez pas enregistrer des activités en dehors de la période de rattachement du salarié sélectionné.";
       default:
         return null;


### PR DESCRIPTION
https://trello.com/c/SljAfxUK/749-modifier-le-message-derreur-lorsque-lon-renseigne-une-date-ant%C3%A9rieure-au-rattachement-du-salari%C3%A9

PR back: https://github.com/MTES-MCT/mobilic-api/pull/102