### PR TITLE
Feat/better controller connection

### DIFF
--- a/common/utils/api.js
+++ b/common/utils/api.js
@@ -238,7 +238,7 @@ class Api {
           if (hasFcToken) {
             window.location.href = buildFCLogoutUrl("/");
           } else if (hasAcToken) {
-            window.location.href = buildAgentConnectLogoutUrl("/");
+            window.location.href = buildAgentConnectLogoutUrl("/logout");
           }
           let error;
           let errorName =

--- a/common/utils/api.js
+++ b/common/utils/api.js
@@ -229,7 +229,9 @@ class Api {
         if (refreshResponse.status !== 200) {
           // User is logged out from the API, update local store
           clearUserIdCookie();
+          clearControllerIdCookie();
           await this.store.updateUserIdAndInfo();
+          await this.store.updateControllerIdAndInfo();
           this.refreshTokenQueue.clear();
           this.nonConcurrentQueryQueue.clear();
           await broadCastChannel.postMessage("update");
@@ -379,6 +381,7 @@ class Api {
         clearUserIdCookie();
         clearControllerIdCookie();
         await this.store.updateUserIdAndInfo();
+        await this.store.updateControllerIdAndInfo();
         await broadCastChannel.postMessage("update");
       }
     }

--- a/web/root.js
+++ b/web/root.js
@@ -218,6 +218,7 @@ function _Root() {
       (!location.pathname.startsWith("/control") ||
         location.pathname.startsWith(CONTROLLER_ROUTE_PREFIX)) &&
       !location.pathname.startsWith("/login") &&
+      !location.pathname.startsWith("/controller-login") &&
       !location.pathname.startsWith("/logout") &&
       !location.pathname.startsWith("/activate_email") &&
       !location.pathname.startsWith("/redeem_invite") &&

--- a/web/signup/AgentConnectCallback.js
+++ b/web/signup/AgentConnectCallback.js
@@ -8,11 +8,15 @@ import Typography from "@mui/material/Typography";
 import { AGENT_CONNECT_LOGIN_MUTATION } from "common/utils/apiQueries";
 import { captureSentryException } from "common/utils/sentry";
 import { removeParamsFromQueryString } from "./FranceConnectCallback";
+import { useSnackbarAlerts } from "../common/Snackbar";
+import { useHistory } from "react-router-dom";
 
 export function AgentConnectCallback() {
   const api = useApi();
   const store = useStoreSyncedWithLocalStorage();
   const withLoadingScreen = useLoadingScreen();
+  const alerts = useSnackbarAlerts();
+  const history = useHistory();
 
   const [error, setError] = React.useState("");
 
@@ -32,13 +36,16 @@ export function AgentConnectCallback() {
         await store.updateControllerIdAndInfo();
       } catch (err) {
         captureSentryException(err);
-        setError(
+        alerts.error(
           formatApiError(err, gqlError => {
             if (graphQLErrorMatchesCode(gqlError, "AUTHENTICATION_ERROR")) {
               return "Erreur lors de la connexion à Mobilic, veuillez réessayer plus tard.";
             }
-          })
+          }),
+          "",
+          6000
         );
+        history.push("/controller-login");
       }
     });
   }


### PR DESCRIPTION
https://trello.com/c/oRIkFujN/775-am%C3%A9lioration-de-la-gestion-des-sessions-contr%C3%B4leur

Petite PR pour corriger trois points dans l'interface contrôleur :
- Quand un contrôleur est logué, s'il retourne sur la page de login controleur, il doit être redirigé vers la home controler. Jusqu'à présent on le laissait se loguer à nouveau.
- S'il y a une erreur technique durant le login contrôleur, on affichait un message d'erreur sur une page blanche, on affiche désormais ce message dans une snackbar, en retournant sur la page de login
- La l'url de post redirection donnée à AgentConnect au moment du logout doit toujours être /logout. Jusqu'à présent il nous arrivait d'envoyer "/".