### PR TITLE
style: display webinar correctly

### DIFF
--- a/web/landing/components/WebinarList.js
+++ b/web/landing/components/WebinarList.js
@@ -152,7 +152,7 @@ export const WebinarList = ({ setCantDisplayWebinarsBecauseNoneOrError }) => {
                           {formatTimeOfDay(webinar.time)}
                         </Typography>
                       </Grid>
-                      <Grid item style={{ flexGrow: 1 }}>
+                      <Grid item style={{ flexGrow: 1, maxWidth: 620 }}>
                         <Typography className={classes.webinarTitle}>
                           {webinar.title}
                         </Typography>


### PR DESCRIPTION
even if title is very long

https://trello.com/c/cDe0aT5I/802-probl%C3%A8me-des-titres-de-webinaire-trop-longs-sur-la-page-daccueil