### PR TITLE
Change wording in mission history event

### DIFF
--- a/common/utils/addresses.js
+++ b/common/utils/addresses.js
@@ -19,7 +19,7 @@ export function formatAddressSubText(address) {
     ? `${address.properties.postcode} ${address.properties.city}`
     : address.postalCode
     ? `${address.postalCode} ${address.city}`
-    : null;
+    : "";
 }
 
 export function buildBackendPayloadForAddress(address) {

--- a/common/utils/time.js
+++ b/common/utils/time.js
@@ -163,13 +163,23 @@ export function isoFormatDateTime(unixTimestamp) {
   )}T${addZero(date.getHours())}:${addZero(date.getMinutes() % 60)}`;
 }
 
-export function formatDateTime(unixTimestamp, showYear = false) {
+export function formatDateTime(
+  unixTimestamp,
+  showYear = false,
+  separator = " "
+) {
   const date = new Date(unixTimestamp * 1000);
   return `${date.toLocaleDateString(undefined, {
     month: "2-digit",
     day: "2-digit",
     year: showYear ? "numeric" : undefined
-  })} ${addZero(date.getHours())}:${addZero(date.getMinutes() % 60)}`;
+  })} ${separator} ${addZero(date.getHours())}:${addZero(
+    date.getMinutes() % 60
+  )}`;
+}
+
+export function formatDateTimeLiteral(unixTimestamp, showYear = false) {
+  return formatDateTime(unixTimestamp, showYear, "à");
 }
 
 export function addZero(n) {

--- a/common/utils/time.js
+++ b/common/utils/time.js
@@ -169,17 +169,21 @@ export function formatDateTime(
   separator = " "
 ) {
   const date = new Date(unixTimestamp * 1000);
-  return `${date.toLocaleDateString(undefined, {
-    month: "2-digit",
-    day: "2-digit",
-    year: showYear ? "numeric" : undefined
-  })} ${separator} ${addZero(date.getHours())}:${addZero(
-    date.getMinutes() % 60
-  )}`;
+  return [
+    date.toLocaleDateString(undefined, {
+      month: "2-digit",
+      day: "2-digit",
+      year: showYear ? "numeric" : undefined
+    }),
+    separator,
+    addZero(date.getHours()),
+    ":",
+    addZero(date.getMinutes() % 60)
+  ].join("");
 }
 
 export function formatDateTimeLiteral(unixTimestamp, showYear = false) {
-  return formatDateTime(unixTimestamp, showYear, "à");
+  return formatDateTime(unixTimestamp, showYear, " à ");
 }
 
 export function addZero(n) {

--- a/web/common/logEvent.js
+++ b/web/common/logEvent.js
@@ -12,6 +12,7 @@ import CheckIcon from "@mui/icons-material/Check";
 import LocationOnIcon from "@mui/icons-material/LocationOn";
 import EuroIcon from "@mui/icons-material/Euro";
 import EditIcon from "@mui/icons-material/Edit";
+import { formatDateTimeLiteral } from "common/utils/time";
 
 function changeResourceAsText(change) {
   switch (change.resourceType) {
@@ -40,46 +41,46 @@ function changeResourceAsText(change) {
   }
 }
 
-function activityChangeText(change, datetimeFormatter) {
+function activityChangeText(change) {
   switch (change.type) {
     case "DELETE":
       return `a supprimé ${changeResourceAsText(change)} ${
         change.before.endTime
-          ? `de ${datetimeFormatter(
+          ? `du ${formatDateTimeLiteral(
               change.before.startTime
-            )} à ${datetimeFormatter(change.before.endTime)}`
-          : `démarrée à ${datetimeFormatter(change.before.startTime)}`
+            )} au ${formatDateTimeLiteral(change.before.endTime)}`
+          : `démarrée le ${formatDateTimeLiteral(change.before.startTime)}`
       }`;
     case "CREATE":
       return change.after.endTime
-        ? `a ajouté ${changeResourceAsText(change)} de ${datetimeFormatter(
+        ? `a ajouté ${changeResourceAsText(change)} du ${formatDateTimeLiteral(
             change.after.startTime
-          )} à ${datetimeFormatter(change.after.endTime)}`
+          )} au ${formatDateTimeLiteral(change.after.endTime)}`
         : `s'est mis en ${
             ACTIVITIES[change.after.type].label
-          } à ${datetimeFormatter(change.after.startTime)}`;
+          } le ${formatDateTimeLiteral(change.after.startTime)}`;
     case "UPDATE":
       return !change.after.endTime && !change.before.endTime
         ? `a décalé le début de ${changeResourceAsText(
             change
-          )} de ${datetimeFormatter(
+          )} du ${formatDateTimeLiteral(
             change.before.startTime
-          )} à ${datetimeFormatter(change.after.startTime)}`
+          )} au ${formatDateTimeLiteral(change.after.startTime)}`
         : change.before.endTime && !change.after.endTime
         ? `a repris ${changeResourceAsText(change)}`
         : !change.before.endTime && change.after.endTime
-        ? `a mis fin à ${changeResourceAsText(change)} à ${datetimeFormatter(
-            change.after.endTime
-          )}`
+        ? `a mis fin à ${changeResourceAsText(
+            change
+          )} le ${formatDateTimeLiteral(change.after.endTime)}`
         : `a modifié la période de ${changeResourceAsText(
             change
-          )} de ${datetimeFormatter(
+          )} de ${formatDateTimeLiteral(
             change.before.startTime
-          )} - ${datetimeFormatter(
+          )} - ${formatDateTimeLiteral(
             change.before.endTime
-          )} à ${datetimeFormatter(
+          )} à ${formatDateTimeLiteral(
             change.after.startTime
-          )} - ${datetimeFormatter(change.after.endTime)}`;
+          )} - ${formatDateTimeLiteral(change.after.endTime)}`;
     default:
       return "";
   }

--- a/web/common/logEvent.js
+++ b/web/common/logEvent.js
@@ -86,14 +86,14 @@ function activityChangeText(change) {
   }
 }
 
-export function getChangeIconAndText(change, datetimeFormatter) {
+export function getChangeIconAndText(change) {
   switch (change.type) {
     case "DELETE":
       switch (change.resourceType) {
         case MISSION_RESOURCE_TYPES.activity:
           return {
             icon: <HighlightOffIcon />,
-            text: activityChangeText(change, datetimeFormatter)
+            text: activityChangeText(change)
           };
         default:
           return {
@@ -122,7 +122,7 @@ export function getChangeIconAndText(change, datetimeFormatter) {
         case MISSION_RESOURCE_TYPES.activity:
           return {
             icon: ACTIVITIES[change.after.type].renderIcon(),
-            text: activityChangeText(change, datetimeFormatter),
+            text: activityChangeText(change),
             color: ACTIVITIES[change.after.type].color
           };
         case MISSION_RESOURCE_TYPES.expenditure:
@@ -138,7 +138,7 @@ export function getChangeIconAndText(change, datetimeFormatter) {
         case MISSION_RESOURCE_TYPES.activity:
           return {
             icon: <EditIcon />,
-            text: activityChangeText(change, datetimeFormatter)
+            text: activityChangeText(change)
           };
         default:
           return "";

--- a/web/pwa/components/ContradictoryChanges.js
+++ b/web/pwa/components/ContradictoryChanges.js
@@ -8,12 +8,7 @@ import { makeStyles } from "@mui/styles";
 import { Event } from "../../common/Event";
 import { MISSION_RESOURCE_TYPES } from "common/utils/contradictory";
 import { getChangeIconAndText } from "../../common/logEvent";
-import {
-  formatDateTime,
-  formatTimeOfDay,
-  getStartOfDay,
-  now
-} from "common/utils/time";
+import { now } from "common/utils/time";
 import { isConnectionError } from "common/utils/errors";
 import { Accordion, AccordionDetails } from "@mui/material";
 import AccordionSummary from "@mui/material/AccordionSummary";
@@ -95,18 +90,6 @@ export function ContradictoryChanges({
       (c.userId === userId || !c.userId) &&
       (showEventsBeforeValidation || c.time >= (validationTime || now()))
   );
-
-  const minStartTime = Math.min(
-    ...userChangesHistory.map(c => c.after?.startTime).filter(Boolean)
-  );
-  const maxEndTime = Math.max(
-    ...userChangesHistory.map(c => c.after?.endTime).filter(Boolean)
-  );
-  const datetimeFormatter =
-    getStartOfDay(minStartTime) === getStartOfDay(maxEndTime)
-      ? formatTimeOfDay
-      : formatDateTime;
-
   return (
     <Accordion
       elevation={0}
@@ -138,10 +121,7 @@ export function ContradictoryChanges({
           <>
             <List dense>
               {userChangesHistory.map(change => {
-                const { icon, text, color } = getChangeIconAndText(
-                  change,
-                  datetimeFormatter
-                );
+                const { icon, text, color } = getChangeIconAndText(change);
                 return (
                   <Event
                     key={`${(change.after || change.before).id}${change.time}`}


### PR DESCRIPTION
https://trello.com/c/OYwxpeAz/803-probl%C3%A8me-de-tournure-des-phrases-dans-lhistorique-de-saisie

Ne plus différencier les missions sur plusieurs jours / sur un seul jour. ==> Simplification des règles pour l'affichage de l'historique de saisie d'une mission.