### PR TITLE
Fix/create inner mission

### DIFF
--- a/common/components/App.js
+++ b/common/components/App.js
@@ -81,7 +81,7 @@ function _App({ ScreenComponent, loadUser }) {
         <Route path={`${path}/history`}>
           <History
             handleBack={() => history.push(path)}
-            missions={missions.filter(m => m.isComplete && m.ended)}
+            missions={missions}
             createActivity={args =>
               actions.pushNewTeamActivityEvent({ ...args, switchMode: false })
             }

--- a/common/utils/mission.js
+++ b/common/utils/mission.js
@@ -75,14 +75,16 @@ export function augmentMissionWithProperties(mission, userId, companies = []) {
       activities.length > 0 ? activities[activities.length - 1].endTime : null,
     teamChanges: computeTeamChanges(mission.allActivities, userId),
     ended: mission.ended && activities.every(a => !!a.endTime),
-    submittedBySomeoneElse: mission.submitter && mission.submitter.id !== userId
+    submittedBySomeoneElse:
+      mission.submitter && mission.submitter.id !== userId,
+    lastActivityStartTime: activities[activities.length - 1]?.startTime
   };
 }
 
 export function augmentAndSortMissions(missions, userId, companies = []) {
   return missions
     .map(m => augmentMissionWithProperties(m, userId, companies))
-    .sort((m1, m2) => m1.startTime - m2.startTime);
+    .sort((m1, m2) => m1.lastActivityStartTime - m2.lastActivityStartTime);
 }
 
 export function computeMissionStats(m, users) {

--- a/web/common/Snackbar.js
+++ b/web/common/Snackbar.js
@@ -87,6 +87,7 @@ export const SnackbarProvider = ({ children }) => {
           horizontal: isSmUp ? "left" : "center",
           vertical: "bottom"
         }}
+        style={{ zIndex: 3000 }}
         autoHideDuration={_autoHideDuration}
         onClose={close}
       >

--- a/web/pwa/components/ContradictoryChanges.js
+++ b/web/pwa/components/ContradictoryChanges.js
@@ -124,7 +124,9 @@ export function ContradictoryChanges({
                 const { icon, text, color } = getChangeIconAndText(change);
                 return (
                   <Event
-                    key={`${(change.after || change.before).id}${change.time}`}
+                    key={`${(change.after || change.before).id}${change.time}${
+                      change.resourceType
+                    }`}
                     icon={icon}
                     iconClassName={iconClassName(change)}
                     text={text}

--- a/web/pwa/screens/History.js
+++ b/web/pwa/screens/History.js
@@ -315,13 +315,13 @@ export function History({
                       const actualMissionId = store.identityMap()[
                         tempMissionId
                       ];
-                      if (!actualMissionId)
+                      if (!actualMissionId) {
                         alerts.error(
-                          "La mission n'a pas pu être créée",
+                          "La mission n'a pas pu être créée. Vérifiez votre connexion internet, vous ne pouvez pas créer de mission passée sans être connecté.",
                           tempMissionId,
                           6000
                         );
-                      else {
+                      } else {
                         history.push(
                           `/app/edit_mission?mission=${actualMissionId}`,
                           { day: missionInfos.day }


### PR DESCRIPTION
https://trello.com/c/T3bXj2VJ/868-erreur-checkintermissionoverlaps-pendant-appel-activitieslogactivity

Plusieurs corrections dans cette PR : 
- Le message d'erreur est plus explicite quand on essaye de créer une mission passée sans être connecté
- Suppression d'erreurs JS à cause de key dupliquées
- La snackbar d'alerte est maintenant visible par dessus les pop up
- La mission courante est celle dont la dernière activité démarre en dernier, plutôt que celle qui démarre en dernier, au cas où il y aurait encore des missions imbriquées.
- On affiche désormais les missions qui ne sont pas finies dans l'historique des missions, sinon on ne pouvait pas voir certaines missions qu'on vient de créer si on ne les a pas validées. Ce dernier point peut être discuter si vous pensez qu'il ne fallait pas changer ce fonctionnement.

PR Back : https://github.com/MTES-MCT/mobilic-api/pull/135