### PR TITLE
Historique en vue salarié récupère et expose les alertes régulation provenant du backend

### DIFF
--- a/common/components/App.js
+++ b/common/components/App.js
@@ -14,6 +14,7 @@ import EditPastMission from "../../web/pwa/components/EditPastMission";
 import { makeStyles } from "@mui/styles";
 import Container from "@mui/material/Container";
 import { sortActivities } from "../utils/activities";
+import { useGetUserRegulationComputationsByDay } from "../utils/regulation/useGetUserRegulationComputationsByDay";
 
 const useStyles = makeStyles(theme => ({
   appContainer: {
@@ -35,6 +36,8 @@ function _App({ ScreenComponent, loadUser }) {
   React.useEffect(() => {
     if (!document.hidden) api.executePendingRequests();
   }, []);
+
+  const [regulationComputationsByDay] = useGetUserRegulationComputationsByDay();
 
   const activities = sortActivities(values(store.getEntity("activities")));
   const expenditures = values(store.getEntity("expenditures"));
@@ -94,6 +97,7 @@ function _App({ ScreenComponent, loadUser }) {
             logComment={actions.logComment}
             cancelComment={actions.cancelComment}
             registerKilometerReading={actions.registerKilometerReading}
+            regulationComputationsByDay={regulationComputationsByDay}
           />
         </Route>
         <Route path={`${path}/edit_mission`}>

--- a/common/utils/apiQueries.js
+++ b/common/utils/apiQueries.js
@@ -451,6 +451,30 @@ export const CONTROLLER_READ_CONTROL_DATA = gql`
   }
 `;
 
+export const ME_READ_REGULATION_COMPUTATIONS_QUERY = gql`
+  query getMyAlerts($fromDate: TimeStamp) {
+    me {
+      regulationComputationsByDay(fromDate: $fromDate) {
+        day
+        regulationComputations {
+          day
+          submitterType
+          regulationChecks {
+            type
+            label
+            description
+            regulationRule
+            unit
+            alert {
+              extra
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
 export const USER_READ_QUERY = gql`
   ${COMPANY_SETTINGS_FRAGMENT}
   ${FRAGMENT_LOCATION_FULL}

--- a/common/utils/regulation/useGetUserRegulationComputationsByDay.js
+++ b/common/utils/regulation/useGetUserRegulationComputationsByDay.js
@@ -1,0 +1,43 @@
+import React from "react";
+import { useSnackbarAlerts } from "../../../web/common/Snackbar";
+import { useApi } from "../api";
+import { ME_READ_REGULATION_COMPUTATIONS_QUERY } from "../apiQueries";
+import { useLoadingScreen } from "../loading";
+import { DAY, now } from "../time";
+import { computeNumberOfAlerts } from "./computeNumberOfAlerts";
+
+export const useGetUserRegulationComputationsByDay = () => {
+  const api = useApi();
+  const withLoadingScreen = useLoadingScreen();
+  const alerts = useSnackbarAlerts();
+  const [
+    regulationComputationsByDay,
+    setRegulationComputationsByDay
+  ] = React.useState([]);
+  React.useEffect(() => {
+    withLoadingScreen(async () => {
+      await alerts.withApiErrorHandling(async () => {
+        const apiResponse = await api.graphQlMutate(
+          ME_READ_REGULATION_COMPUTATIONS_QUERY,
+          {
+            fromDate: now() - DAY * 215
+          },
+          { context: { nonPublicApi: false } }
+        );
+
+        setRegulationComputationsByDay(
+          apiResponse.data.me.regulationComputationsByDay
+        );
+      });
+    });
+  }, []);
+
+  const alertNumber = React.useMemo(() => {
+    if (!regulationComputationsByDay) {
+      return 0;
+    }
+    return computeNumberOfAlerts(regulationComputationsByDay);
+  }, [regulationComputationsByDay]);
+
+  return [regulationComputationsByDay, alertNumber];
+};

--- a/web/control/UserRead.js
+++ b/web/control/UserRead.js
@@ -28,6 +28,7 @@ import { TextWithBadge } from "../common/TextWithBadge";
 import { UserReadAlerts } from "./components/UserReadAlerts";
 import { computeAlerts } from "common/utils/regulation/computeAlerts";
 import { getDaysBetweenTwoDates } from "common/utils/time";
+import { useGetUserRegulationComputationsByDay } from "common/utils/regulation/useGetUserRegulationComputationsByDay";
 
 export function getTabs(alertsNumber) {
   return [
@@ -75,6 +76,10 @@ export function UserRead() {
   const [periodOnFocus, setPeriodOnFocus] = React.useState(null);
   const [groupedAlerts, setGroupedAlerts] = React.useState([]);
   const [workingDays, setWorkingDays] = React.useState(new Set([]));
+  const [
+    regulationComputationsByDay,
+    alertNumber
+  ] = useGetUserRegulationComputationsByDay();
 
   const [error, setError] = React.useState("");
 
@@ -184,10 +189,6 @@ export function UserRead() {
     }
   }, [impersonatingUser]);
 
-  const alertNumber = groupedAlerts.reduce(
-    (acc, group) => acc + group.alerts.length,
-    0
-  );
   const TABS = getTabs(alertNumber);
 
   return [
@@ -214,6 +215,7 @@ export function UserRead() {
         periodOnFocus={periodOnFocus}
         setPeriodOnFocus={setPeriodOnFocus}
         workingDaysNumber={workingDays.size}
+        regulationComputationsByDay={regulationComputationsByDay}
       />
     ) : null
   ];


### PR DESCRIPTION
https://trello.com/c/bb1BMCFR/891-modifier-le-calcul-des-alertes-dans-lhistorique-salari%C3%A9

Vue historique du salarié / Vue contrôle par un contrôleur non connecté via QR code => Alertes de régulation du back