### PR TITLE
Fix/users regulation computations in store

### DIFF
--- a/common/components/App.js
+++ b/common/components/App.js
@@ -14,7 +14,6 @@ import EditPastMission from "../../web/pwa/components/EditPastMission";
 import { makeStyles } from "@mui/styles";
 import Container from "@mui/material/Container";
 import { sortActivities } from "../utils/activities";
-import { useGetUserRegulationComputationsByDay } from "../utils/regulation/useGetUserRegulationComputationsByDay";
 
 const useStyles = makeStyles(theme => ({
   appContainer: {
@@ -37,8 +36,8 @@ function _App({ ScreenComponent, loadUser }) {
     if (!document.hidden) api.executePendingRequests();
   }, []);
 
-  const regulationComputationsByDay = useGetUserRegulationComputationsByDay(
-    store.userId()
+  const regulationComputationsByDay = values(
+    store.getEntity("regulationComputationsByDay")
   );
 
   const activities = sortActivities(values(store.getEntity("activities")));

--- a/common/store/schemas.js
+++ b/common/store/schemas.js
@@ -19,7 +19,8 @@ export const LOCAL_STORAGE_SCHEMA = {
   comments: Map,
   missions: Map,
   expenditures: Map,
-  vehicles: Map
+  vehicles: Map,
+  regulationComputationsByDay: List
 };
 
 export const NON_PERSISTENT_SCHEMA = {

--- a/common/utils/regulation/useGetUserRegulationComputationsByDay.js
+++ b/common/utils/regulation/useGetUserRegulationComputationsByDay.js
@@ -57,8 +57,8 @@ export const useGetUserRegulationComputationsForDate = (
         setRegulationComputations(
           regulationComputationsByDay[0].regulationComputations
         );
-        setLoading(false);
       }
+      setLoading(false);
     });
   }, []);
 

--- a/common/utils/regulation/useGetUserRegulationComputationsByDay.js
+++ b/common/utils/regulation/useGetUserRegulationComputationsByDay.js
@@ -2,7 +2,6 @@ import React from "react";
 import { useSnackbarAlerts } from "../../../web/common/Snackbar";
 import { useApi } from "../api";
 import { USER_READ_REGULATION_COMPUTATIONS_QUERY } from "../apiQueries";
-import { useLoadingScreen } from "../loading";
 import { DEFAULT_NB_DAYS_MISSIONS_HISTORY } from "../mission";
 import { DAY, isoFormatLocalDate, now } from "../time";
 import { computeNumberOfAlerts } from "./computeNumberOfAlerts";
@@ -28,34 +27,6 @@ export const getRegulationComputationsAndAlertNumber = async (api, userId) => {
     alertNumber = computeNumberOfAlerts(regulationComputationsByDay);
   }
   return { regulationComputationsByDay, alertNumber };
-};
-
-export const useGetUserRegulationComputationsByDay = userId => {
-  const api = useApi();
-  const withLoadingScreen = useLoadingScreen();
-  const alerts = useSnackbarAlerts();
-  const [
-    regulationComputationsByDay,
-    setRegulationComputationsByDay
-  ] = React.useState([]);
-
-  React.useEffect(() => {
-    withLoadingScreen(async () => {
-      await alerts.withApiErrorHandling(async () => {
-        const apiResponse = await getRegulationComputationsAndAlertNumber(
-          api,
-          userId
-        );
-        if (apiResponse.regulationComputationsByDay) {
-          setRegulationComputationsByDay(
-            apiResponse.regulationComputationsByDay
-          );
-        }
-      });
-    });
-  }, []);
-
-  return regulationComputationsByDay;
 };
 
 export const useGetUserRegulationComputationsForDate = (

--- a/web/pwa/components/history/DaySummary.js
+++ b/web/pwa/components/history/DaySummary.js
@@ -51,10 +51,7 @@ export function DaySummary({
         )}
       </InfoCard>
       {process.env.REACT_APP_SHOW_BACKEND_REGULATION_COMPUTATIONS === "1" && (
-        <InfoCard
-          loading={loading || !regulationComputation}
-          className={infoCardStyles.topMargin}
-        >
+        <InfoCard loading={loading} className={infoCardStyles.topMargin}>
           <DayRegulatoryAlerts regulationComputation={regulationComputation} />
         </InfoCard>
       )}


### PR DESCRIPTION
https://trello.com/c/3UURlSdv/930-mettre-%C3%A0-jour-les-alertes-pour-les-journ%C3%A9es-concern%C3%A9es-par-la-derni%C3%A8re-mission-valid%C3%A9e

ETQ salarié, lorsque je valide une mission, je souhaite que les alertes soient automatiquement à jour dans mon historique