### PR TITLE
Fix/display alerts

### DIFF
--- a/common/utils/regulation/alertTypes.js
+++ b/common/utils/regulation/alertTypes.js
@@ -92,14 +92,12 @@ export const ALERT_TYPE_PROPS_SIMPLER = {
   },
   [ALERT_TYPES.maximumWorkDayTime]: {
     successMessage: () => "Durée du travail quotidien respectée",
-    errorMessage: ({ max_time_in_hours }, label) =>
-      `${label} (${max_time_in_hours}h)`,
+    errorMessage: (_, label) => label,
     rule: REGULATION_RULES.dailyWork
   },
   [ALERT_TYPES.minimumWorkDayBreak]: {
     successMessage: () => "Temps de pause respecté",
-    errorMessage: ({ min_time_in_minutes }, label) =>
-      `${label} (${min_time_in_minutes}m)`,
+    errorMessage: (_, label) => label,
     rule: REGULATION_RULES.dailyRest
   },
   [ALERT_TYPES.maximumUninterruptedWorkTime]: {

--- a/web/admin/components/WorkTimeDetails.js
+++ b/web/admin/components/WorkTimeDetails.js
@@ -35,6 +35,7 @@ import { OPEN_MISSION_DRAWER_IN_WORKDAY_PANEL } from "common/utils/matomoTags";
 import { DayRegulatoryAlerts } from "../../regulatory/DayRegulatoryAlerts";
 import { useGetUserRegulationComputationsForDate } from "common/utils/regulation/useGetUserRegulationComputationsByDay";
 import { getLatestAlertComputationVersion } from "common/utils/regulation/alertVersions";
+import { WeekRegulatoryAlerts } from "../../regulatory/WeekRegulatoryAlerts";
 
 export function WorkTimeDetails({ workTimeEntry, handleClose, openMission }) {
   const classes = useStyles();
@@ -275,10 +276,20 @@ export function WorkTimeDetails({ workTimeEntry, handleClose, openMission }) {
             loading={loadingRegulation}
             className={classes.regulatoryAlertCard}
           >
-            <div>Nouvelles alertes</div>
+            <div>Alertes quotidiennes</div>
             <DayRegulatoryAlerts
               regulationComputation={regulationComputation}
             />
+            {getStartOfWeek(workTimeEntry.periodStart) ===
+              workTimeEntry.periodStart && (
+              <>
+                <br></br>
+                <div>Alertes hebdomadaires</div>
+                <WeekRegulatoryAlerts
+                  regulationComputation={regulationComputation}
+                />
+              </>
+            )}
           </MissionInfoCard>
         </Grid>
       )}

--- a/web/regulatory/RegulatoryText.js
+++ b/web/regulatory/RegulatoryText.js
@@ -22,6 +22,17 @@ export function RegulatoryTextDayBeforeAndAfter() {
   );
 }
 
+export function RegulatoryTextWeekBeforeAndAfter() {
+  const classes = useStyles();
+
+  return (
+    <Typography className={classes.infoText} variant="body2">
+      Les seuils hebdomadaires prennent en compte le temps de travail de la
+      semaine complète.
+    </Typography>
+  );
+}
+
 export function RegulatoryTextNotCalculatedYet() {
   const classes = useStyles();
   return (

--- a/web/regulatory/WeekRegulatoryAlerts.js
+++ b/web/regulatory/WeekRegulatoryAlerts.js
@@ -7,7 +7,6 @@ import {
 } from "./RegulatoryText";
 
 export function WeekRegulatoryAlerts({ regulationComputation }) {
-  console.log(regulationComputation);
   return regulationComputation ? (
     <>
       <RegulatoryTextWeekBeforeAndAfter />

--- a/web/regulatory/WeekRegulatoryAlerts.js
+++ b/web/regulatory/WeekRegulatoryAlerts.js
@@ -1,0 +1,21 @@
+import { PERIOD_UNITS } from "common/utils/regulation/periodUnitsEnum";
+import React from "react";
+import { renderRegulationCheck } from "./RegulatoryAlertRender";
+import {
+  RegulatoryTextNotCalculatedYet,
+  RegulatoryTextWeekBeforeAndAfter
+} from "./RegulatoryText";
+
+export function WeekRegulatoryAlerts({ regulationComputation }) {
+  console.log(regulationComputation);
+  return regulationComputation ? (
+    <>
+      <RegulatoryTextWeekBeforeAndAfter />
+      {regulationComputation.regulationChecks
+        ?.filter(regulationCheck => regulationCheck.unit === PERIOD_UNITS.WEEK)
+        .map(regulationCheck => renderRegulationCheck(regulationCheck))}
+    </>
+  ) : (
+    <RegulatoryTextNotCalculatedYet />
+  );
+}


### PR DESCRIPTION
Retour recette:
- Vue gestionnaire: les lundi on souhaite afficher les alertes hebdomadaires
- Recap des alertes: dans un premier temps, on enleve les infos additionnelles entre parentheses. Un ticket va être créé pour renseigner les informations que les contrôleurs souhaiteraient voir dans une version future (par exemple: dépassement du temps de travail => de combien de minutes le seuil est-il depasse ?) 