### PR TITLE
Do not load regulation computation on login as it would slow down the app

### DIFF
--- a/common/utils/actions.js
+++ b/common/utils/actions.js
@@ -7,20 +7,15 @@ import {
   ACTIVITIES_OPERATIONS,
   parseActivityPayloadFromBackend
 } from "./activities";
-import {
-  DEFAULT_NB_DAYS_MISSIONS_HISTORY,
-  parseMissionPayloadFromBackend
-} from "./mission";
+import { parseMissionPayloadFromBackend } from "./mission";
 import {
   formatNameInGqlError,
   graphQLErrorMatchesCode,
   isGraphQLError
 } from "./errors";
 import {
-  DAY,
   formatDay,
   formatTimeOfDay,
-  isoFormatLocalDate,
   now,
   nowMilliseconds,
   sameMinute,
@@ -48,7 +43,6 @@ import {
   LOG_LOCATION_MUTATION,
   REGISTER_KILOMETER_AT_LOCATION,
   UPDATE_MISSION_VEHICLE_MUTATION,
-  USER_READ_REGULATION_COMPUTATIONS_QUERY,
   VALIDATE_MISSION_MUTATION
 } from "./apiQueries";
 import { hasPendingUpdates } from "../store/offline";
@@ -309,16 +303,6 @@ class Actions {
             isActionDescriptionFemale: true
           });
         }
-      }
-    });
-
-    api.registerResponseHandler("updateRegulationComputations", {
-      onSuccess: async apiResponse => {
-        const regulationComputations =
-          apiResponse.data.user.regulationComputationsByDay;
-        this.store.setItems({
-          regulationComputationsByDay: regulationComputations
-        });
       }
     });
 
@@ -1248,19 +1232,6 @@ class Actions {
       updateStore,
       ["missions"],
       "validateMission"
-    );
-
-    await this.submitAction(
-      USER_READ_REGULATION_COMPUTATIONS_QUERY,
-      {
-        userId,
-        fromDate: isoFormatLocalDate(
-          now() - DAY * DEFAULT_NB_DAYS_MISSIONS_HISTORY
-        )
-      },
-      () => {},
-      [],
-      "updateRegulationComputations"
     );
   };
 

--- a/web/admin/components/WorkTimeDetails.js
+++ b/web/admin/components/WorkTimeDetails.js
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React from "react";
 import { AugmentedTable } from "./AugmentedTable";
 import Grid from "@mui/material/Grid";
 import Box from "@mui/material/Box";
@@ -33,8 +33,6 @@ import { ActivitiesCard } from "./ActivitiesCard";
 import { useMatomo } from "@datapunt/matomo-tracker-react";
 import { OPEN_MISSION_DRAWER_IN_WORKDAY_PANEL } from "common/utils/matomoTags";
 import { DayRegulatoryAlerts } from "../../regulatory/DayRegulatoryAlerts";
-import { useGetUserRegulationComputationsForDate } from "common/utils/regulation/useGetUserRegulationComputationsByDay";
-import { getLatestAlertComputationVersion } from "common/utils/regulation/alertVersions";
 import { WeekRegulatoryAlerts } from "../../regulatory/WeekRegulatoryAlerts";
 
 export function WorkTimeDetails({ workTimeEntry, handleClose, openMission }) {
@@ -45,19 +43,8 @@ export function WorkTimeDetails({ workTimeEntry, handleClose, openMission }) {
   const [activitiesOver3Days, setActivitiesOver3Days] = React.useState([]);
   const [missions, setMissions] = React.useState([]);
   const [loading, setLoading] = React.useState(false);
-  const [loadingRegulation, setLoadingRegulation] = React.useState(false);
   const { trackEvent } = useMatomo();
 
-  const regulationComputations = useGetUserRegulationComputationsForDate(
-    workTimeEntry.user.id,
-    isoFormatLocalDate(workTimeEntry.periodActualStart),
-    setLoadingRegulation
-  );
-  const regulationComputation = useMemo(
-    () => getLatestAlertComputationVersion(regulationComputations),
-
-    [regulationComputations]
-  );
   const periodEnd = new Date(workTimeEntry.periodStart * 1000 + DAY * 1000);
 
   const nameMissionCol = {
@@ -273,12 +260,12 @@ export function WorkTimeDetails({ workTimeEntry, handleClose, openMission }) {
         <Grid item xs={12}>
           <MissionInfoCard
             title="Seuils réglementaires"
-            loading={loadingRegulation}
             className={classes.regulatoryAlertCard}
           >
             <div>Alertes quotidiennes</div>
             <DayRegulatoryAlerts
-              regulationComputation={regulationComputation}
+              userId={workTimeEntry.user.id}
+              day={isoFormatLocalDate(workTimeEntry.periodActualStart)}
             />
             {getStartOfWeek(workTimeEntry.periodStart) ===
               workTimeEntry.periodStart && (
@@ -286,7 +273,8 @@ export function WorkTimeDetails({ workTimeEntry, handleClose, openMission }) {
                 <br></br>
                 <div>Alertes hebdomadaires</div>
                 <WeekRegulatoryAlerts
-                  regulationComputation={regulationComputation}
+                  userId={workTimeEntry.user.id}
+                  day={isoFormatLocalDate(workTimeEntry.periodActualStart)}
                 />
               </>
             )}

--- a/web/pwa/components/history/Day.js
+++ b/web/pwa/components/history/Day.js
@@ -15,6 +15,7 @@ import {
   getAlertComputationVersion,
   getLatestAlertComputationVersion
 } from "common/utils/regulation/alertVersions";
+import { currentControllerId } from "common/utils/cookie";
 
 export const useStyles = makeStyles(theme => ({
   contradictorySwitch: {
@@ -145,9 +146,8 @@ export function Day({
         dayStart={selectedPeriodStart}
         weekActivities={weekActivities}
         prefetchedRegulationComputation={
-          controlId ? regulationComputationToUse : null
+          currentControllerId() ? regulationComputationToUse : null
         }
-        shouldFetchRegulationComputation={!controlId}
         loading={loadingEmployeeVersion}
         userId={userId}
         shouldDisplayInitialEmployeeVersion={

--- a/web/pwa/components/history/Day.js
+++ b/web/pwa/components/history/Day.js
@@ -84,29 +84,31 @@ export function Day({
   ];
 
   React.useEffect(() => {
-    if (
-      !canDisplayContradictoryVersions ||
-      contradictoryComputationError ||
-      (hasComputedContradictory && contradictoryIsEmpty)
-    ) {
-      // No contradictory => use latest version
-      setRegulationComputationToUse(
-        getLatestAlertComputationVersion(regulationComputationsInPeriod)
-      );
-    } else if (shouldDisplayInitialEmployeeVersion) {
-      setRegulationComputationToUse(
-        getAlertComputationVersion(
-          regulationComputationsInPeriod,
-          SubmitterType.EMPLOYEE
-        )
-      );
-    } else {
-      setRegulationComputationToUse(
-        getAlertComputationVersion(
-          regulationComputationsInPeriod,
-          SubmitterType.ADMIN
-        )
-      );
+    if (controlId) {
+      if (
+        !canDisplayContradictoryVersions ||
+        contradictoryComputationError ||
+        (hasComputedContradictory && contradictoryIsEmpty)
+      ) {
+        // No contradictory => use latest version
+        setRegulationComputationToUse(
+          getLatestAlertComputationVersion(regulationComputationsInPeriod)
+        );
+      } else if (shouldDisplayInitialEmployeeVersion) {
+        setRegulationComputationToUse(
+          getAlertComputationVersion(
+            regulationComputationsInPeriod,
+            SubmitterType.EMPLOYEE
+          )
+        );
+      } else {
+        setRegulationComputationToUse(
+          getAlertComputationVersion(
+            regulationComputationsInPeriod,
+            SubmitterType.ADMIN
+          )
+        );
+      }
     }
   }, [
     regulationComputationsInPeriod,
@@ -142,8 +144,15 @@ export function Day({
         isDayEnded={true}
         dayStart={selectedPeriodStart}
         weekActivities={weekActivities}
-        regulationComputation={regulationComputationToUse}
+        prefetchedRegulationComputation={
+          controlId ? regulationComputationToUse : null
+        }
+        shouldFetchRegulationComputation={!controlId}
         loading={loadingEmployeeVersion}
+        userId={userId}
+        shouldDisplayInitialEmployeeVersion={
+          shouldDisplayInitialEmployeeVersion
+        }
       />
       <InfoCard className={infoCardStyles.topMargin}>
         <MissionReviewSection

--- a/web/pwa/components/history/DaySummary.js
+++ b/web/pwa/components/history/DaySummary.js
@@ -8,7 +8,7 @@ import { ItalicWarningTypography } from "./ItalicWarningTypography";
 import { MissionReviewSection } from "../MissionReviewSection";
 import { ActivityList } from "../ActivityList";
 import React from "react";
-import { DAY } from "common/utils/time";
+import { DAY, isoFormatLocalDate } from "common/utils/time";
 import { InfoCard, useInfoCardStyles } from "../../../common/InfoCard";
 import { DayRegulatoryAlerts } from "../../../regulatory/DayRegulatoryAlerts";
 
@@ -17,8 +17,11 @@ export function DaySummary({
   activitiesWithNextAndPreviousDay,
   weekActivities,
   dayStart,
-  regulationComputation,
-  loading = false
+  userId,
+  loading = false,
+  shouldDisplayInitialEmployeeVersion = false,
+  prefetchedRegulationComputation = null,
+  shouldFetchRegulationComputation = true
 }) {
   const dayEnd = dayStart + DAY;
   const infoCardStyles = useInfoCardStyles();
@@ -51,8 +54,16 @@ export function DaySummary({
         )}
       </InfoCard>
       {process.env.REACT_APP_SHOW_BACKEND_REGULATION_COMPUTATIONS === "1" && (
-        <InfoCard loading={loading} className={infoCardStyles.topMargin}>
-          <DayRegulatoryAlerts regulationComputation={regulationComputation} />
+        <InfoCard className={infoCardStyles.topMargin}>
+          <DayRegulatoryAlerts
+            day={isoFormatLocalDate(dayStart)}
+            userId={userId}
+            shouldDisplayInitialEmployeeVersion={
+              shouldDisplayInitialEmployeeVersion
+            }
+            prefetchedRegulationComputation={prefetchedRegulationComputation}
+            shouldFetchRegulationComputation={shouldFetchRegulationComputation}
+          />
         </InfoCard>
       )}
       <InfoCard className={infoCardStyles.topMargin}>

--- a/web/pwa/components/history/DaySummary.js
+++ b/web/pwa/components/history/DaySummary.js
@@ -20,8 +20,7 @@ export function DaySummary({
   userId,
   loading = false,
   shouldDisplayInitialEmployeeVersion = false,
-  prefetchedRegulationComputation = null,
-  shouldFetchRegulationComputation = true
+  prefetchedRegulationComputation = null
 }) {
   const dayEnd = dayStart + DAY;
   const infoCardStyles = useInfoCardStyles();
@@ -62,7 +61,6 @@ export function DaySummary({
               shouldDisplayInitialEmployeeVersion
             }
             prefetchedRegulationComputation={prefetchedRegulationComputation}
-            shouldFetchRegulationComputation={shouldFetchRegulationComputation}
           />
         </InfoCard>
       )}

--- a/web/pwa/components/history/Week.js
+++ b/web/pwa/components/history/Week.js
@@ -16,6 +16,7 @@ import Divider from "@mui/material/Divider";
 import { InfoCard, useInfoCardStyles } from "../../../common/InfoCard";
 import { getLatestAlertComputationVersion } from "common/utils/regulation/alertVersions";
 import { WeekRegulatoryAlerts } from "../../../regulatory/WeekRegulatoryAlerts";
+import { currentControllerId } from "common/utils/cookie";
 
 export function Week({
   missionsInPeriod,
@@ -61,9 +62,8 @@ export function Week({
             userId={userId}
             day={isoFormatLocalDate(selectedPeriodStart)}
             prefetchedRegulationComputation={
-              controlId ? regulationComputation : null
+              currentControllerId() ? regulationComputation : null
             }
-            shouldFetchRegulationComputation={!controlId}
           />
         </InfoCard>
       )}

--- a/web/pwa/components/history/Week.js
+++ b/web/pwa/components/history/Week.js
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
 import {
-  splitByLongBreaksAndComputePeriodStats,
   renderPeriodKpis,
+  splitByLongBreaksAndComputePeriodStats,
   WorkTimeSummaryKpiGrid
 } from "../WorkTimeSummary";
 import { RegulationCheck } from "../RegulationCheck";
@@ -11,13 +11,11 @@ import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import ListItemText from "@mui/material/ListItemText";
 import Link from "@mui/material/Link";
-import { prettyFormatDay } from "common/utils/time";
+import { isoFormatLocalDate, prettyFormatDay } from "common/utils/time";
 import Divider from "@mui/material/Divider";
 import { InfoCard, useInfoCardStyles } from "../../../common/InfoCard";
 import { getLatestAlertComputationVersion } from "common/utils/regulation/alertVersions";
-import { RegulatoryTextNotCalculatedYet } from "../../../regulatory/RegulatoryText";
-import { renderRegulationCheck } from "../../../regulatory/RegulatoryAlertRender";
-import { PERIOD_UNITS } from "common/utils/regulation/periodUnitsEnum";
+import { WeekRegulatoryAlerts } from "../../../regulatory/WeekRegulatoryAlerts";
 
 export function Week({
   missionsInPeriod,
@@ -26,7 +24,9 @@ export function Week({
   selectedPeriodEnd,
   handleMissionClick,
   previousPeriodActivityEnd,
-  regulationComputationsInPeriod
+  regulationComputationsInPeriod,
+  userId,
+  controlId
 }) {
   const infoCardStyles = useInfoCardStyles();
 
@@ -57,15 +57,14 @@ export function Week({
       </InfoCard>
       {process.env.REACT_APP_SHOW_BACKEND_REGULATION_COMPUTATIONS === "1" && (
         <InfoCard className={infoCardStyles.topMargin}>
-          {regulationComputation ? (
-            regulationComputation.regulationChecks
-              ?.filter(
-                regulationCheck => regulationCheck.unit === PERIOD_UNITS.WEEK
-              )
-              .map(regulationCheck => renderRegulationCheck(regulationCheck))
-          ) : (
-            <RegulatoryTextNotCalculatedYet />
-          )}
+          <WeekRegulatoryAlerts
+            userId={userId}
+            day={isoFormatLocalDate(selectedPeriodStart)}
+            prefetchedRegulationComputation={
+              controlId ? regulationComputation : null
+            }
+            shouldFetchRegulationComputation={!controlId}
+          />
         </InfoCard>
       )}
       <InfoCard className={infoCardStyles.topMargin}>

--- a/web/regulatory/DayRegulatoryAlerts.js
+++ b/web/regulatory/DayRegulatoryAlerts.js
@@ -1,24 +1,20 @@
 import { PERIOD_UNITS } from "common/utils/regulation/periodUnitsEnum";
 import React from "react";
 import { GenericRegulatoryAlerts } from "./GenericRegulatoryAlerts";
-import { RegulatoryTextDayBeforeAndAfter } from "./RegulatoryText";
 
 export function DayRegulatoryAlerts({
   userId,
   day,
   prefetchedRegulationComputation,
-  shouldDisplayInitialEmployeeVersion = false,
-  shouldFetchRegulationComputation = true
+  shouldDisplayInitialEmployeeVersion = false
 }) {
   return (
     <GenericRegulatoryAlerts
       userId={userId}
       day={day}
       shouldDisplayInitialEmployeeVersion={shouldDisplayInitialEmployeeVersion}
-      shouldFetchRegulationComputation={shouldFetchRegulationComputation}
       prefetchedRegulationComputation={prefetchedRegulationComputation}
       regulationCheckUnit={PERIOD_UNITS.DAY}
-      explanationTextComponent={<RegulatoryTextDayBeforeAndAfter />}
     />
   );
 }

--- a/web/regulatory/DayRegulatoryAlerts.js
+++ b/web/regulatory/DayRegulatoryAlerts.js
@@ -1,20 +1,24 @@
 import { PERIOD_UNITS } from "common/utils/regulation/periodUnitsEnum";
 import React from "react";
-import { renderRegulationCheck } from "./RegulatoryAlertRender";
-import {
-  RegulatoryTextDayBeforeAndAfter,
-  RegulatoryTextNotCalculatedYet
-} from "./RegulatoryText";
+import { GenericRegulatoryAlerts } from "./GenericRegulatoryAlerts";
+import { RegulatoryTextDayBeforeAndAfter } from "./RegulatoryText";
 
-export function DayRegulatoryAlerts({ regulationComputation }) {
-  return regulationComputation ? (
-    <>
-      <RegulatoryTextDayBeforeAndAfter />
-      {regulationComputation.regulationChecks
-        ?.filter(regulationCheck => regulationCheck.unit === PERIOD_UNITS.DAY)
-        .map(regulationCheck => renderRegulationCheck(regulationCheck))}
-    </>
-  ) : (
-    <RegulatoryTextNotCalculatedYet />
+export function DayRegulatoryAlerts({
+  userId,
+  day,
+  prefetchedRegulationComputation,
+  shouldDisplayInitialEmployeeVersion = false,
+  shouldFetchRegulationComputation = true
+}) {
+  return (
+    <GenericRegulatoryAlerts
+      userId={userId}
+      day={day}
+      shouldDisplayInitialEmployeeVersion={shouldDisplayInitialEmployeeVersion}
+      shouldFetchRegulationComputation={shouldFetchRegulationComputation}
+      prefetchedRegulationComputation={prefetchedRegulationComputation}
+      regulationCheckUnit={PERIOD_UNITS.DAY}
+      explanationTextComponent={<RegulatoryTextDayBeforeAndAfter />}
+    />
   );
 }

--- a/web/regulatory/GenericRegulatoryAlerts.js
+++ b/web/regulatory/GenericRegulatoryAlerts.js
@@ -1,0 +1,88 @@
+import React from "react";
+import { renderRegulationCheck } from "./RegulatoryAlertRender";
+import { RegulatoryTextNotCalculatedYet } from "./RegulatoryText";
+import { USER_READ_REGULATION_COMPUTATIONS_QUERY } from "common/utils/apiQueries";
+import { useApi } from "common/utils/api";
+import { useSnackbarAlerts } from "../common/Snackbar";
+import Skeleton from "@mui/material/Skeleton";
+import {
+  getAlertComputationVersion,
+  getLatestAlertComputationVersion
+} from "common/utils/regulation/alertVersions";
+import { SubmitterType } from "common/utils/regulation/alertTypes";
+
+export function GenericRegulatoryAlerts({
+  userId,
+  day,
+  prefetchedRegulationComputation,
+  regulationCheckUnit,
+  shouldDisplayInitialEmployeeVersion = false,
+  shouldFetchRegulationComputation = true,
+  explanationTextComponent
+}) {
+  const [regulationComputations, setRegulationComputations] = React.useState(
+    []
+  );
+  const [loading, setLoading] = React.useState(false);
+
+  const api = useApi();
+  const alerts = useSnackbarAlerts();
+
+  React.useEffect(async () => {
+    setLoading(true);
+    if (!shouldFetchRegulationComputation) {
+      setRegulationComputations(prefetchedRegulationComputation);
+    } else {
+      await alerts.withApiErrorHandling(async () => {
+        const apiResponse = await api.graphQlQuery(
+          USER_READ_REGULATION_COMPUTATIONS_QUERY,
+          {
+            userId: userId,
+            fromDate: day,
+            toDate: day
+          }
+        );
+        const { regulationComputationsByDay } = apiResponse.data.user;
+        if (regulationComputationsByDay?.length !== 1) {
+          setRegulationComputations(null);
+        } else {
+          if (shouldDisplayInitialEmployeeVersion) {
+            setRegulationComputations(
+              getAlertComputationVersion(
+                regulationComputationsByDay[0].regulationComputations,
+                SubmitterType.EMPLOYEE
+              )
+            );
+          } else {
+            setRegulationComputations(
+              getLatestAlertComputationVersion(
+                regulationComputationsByDay[0].regulationComputations
+              )
+            );
+          }
+        }
+      });
+    }
+    setLoading(false);
+  }, [
+    day,
+    userId,
+    prefetchedRegulationComputation,
+    shouldDisplayInitialEmployeeVersion
+  ]);
+
+  return loading ? (
+    <Skeleton variant="rectangular" width="100%" height={300} />
+  ) : regulationComputations ? (
+    <>
+      {explanationTextComponent}
+      {regulationComputations.regulationChecks
+        ?.filter(
+          regulationCheck => regulationCheck.unit === regulationCheckUnit
+        )
+        .map(regulationCheck => renderRegulationCheck(regulationCheck))}
+    </>
+  ) : (
+    <RegulatoryTextNotCalculatedYet />
+  );
+}

--- a/web/regulatory/WeekRegulatoryAlerts.js
+++ b/web/regulatory/WeekRegulatoryAlerts.js
@@ -1,20 +1,24 @@
 import { PERIOD_UNITS } from "common/utils/regulation/periodUnitsEnum";
 import React from "react";
-import { renderRegulationCheck } from "./RegulatoryAlertRender";
-import {
-  RegulatoryTextNotCalculatedYet,
-  RegulatoryTextWeekBeforeAndAfter
-} from "./RegulatoryText";
+import { GenericRegulatoryAlerts } from "./GenericRegulatoryAlerts";
+import { RegulatoryTextWeekBeforeAndAfter } from "./RegulatoryText";
 
-export function WeekRegulatoryAlerts({ regulationComputation }) {
-  return regulationComputation ? (
-    <>
-      <RegulatoryTextWeekBeforeAndAfter />
-      {regulationComputation.regulationChecks
-        ?.filter(regulationCheck => regulationCheck.unit === PERIOD_UNITS.WEEK)
-        .map(regulationCheck => renderRegulationCheck(regulationCheck))}
-    </>
-  ) : (
-    <RegulatoryTextNotCalculatedYet />
+export function WeekRegulatoryAlerts({
+  userId,
+  day,
+  shouldDisplayInitialEmployeeVersion,
+  prefetchedRegulationComputation,
+  shouldFetchRegulationComputation = true
+}) {
+  return (
+    <GenericRegulatoryAlerts
+      userId={userId}
+      day={day}
+      shouldDisplayInitialEmployeeVersion={shouldDisplayInitialEmployeeVersion}
+      shouldFetchRegulationComputation={shouldFetchRegulationComputation}
+      prefetchedRegulationComputation={prefetchedRegulationComputation}
+      regulationCheckUnit={PERIOD_UNITS.WEEK}
+      explanationTextComponent={<RegulatoryTextWeekBeforeAndAfter />}
+    />
   );
 }

--- a/web/regulatory/WeekRegulatoryAlerts.js
+++ b/web/regulatory/WeekRegulatoryAlerts.js
@@ -1,24 +1,20 @@
 import { PERIOD_UNITS } from "common/utils/regulation/periodUnitsEnum";
 import React from "react";
 import { GenericRegulatoryAlerts } from "./GenericRegulatoryAlerts";
-import { RegulatoryTextWeekBeforeAndAfter } from "./RegulatoryText";
 
 export function WeekRegulatoryAlerts({
   userId,
   day,
   shouldDisplayInitialEmployeeVersion,
-  prefetchedRegulationComputation,
-  shouldFetchRegulationComputation = true
+  prefetchedRegulationComputation
 }) {
   return (
     <GenericRegulatoryAlerts
       userId={userId}
       day={day}
       shouldDisplayInitialEmployeeVersion={shouldDisplayInitialEmployeeVersion}
-      shouldFetchRegulationComputation={shouldFetchRegulationComputation}
       prefetchedRegulationComputation={prefetchedRegulationComputation}
       regulationCheckUnit={PERIOD_UNITS.WEEK}
-      explanationTextComponent={<RegulatoryTextWeekBeforeAndAfter />}
     />
   );
 }


### PR DESCRIPTION
https://trello.com/c/y2WYnLa8/972-ne-pas-r%C3%A9cup%C3%A9rer-les-seuils-c%C3%B4t%C3%A9-d%C3%A8s-le-login

Deux points peuvent encore être optimisés : 
- Lors de l'affichage du drawer workday d'un lundi dans l'interface admin, on fait deux fois la même requête pour récupérer les seuils du jour et de la semaine
- Dans la nouvelle interface contrôleur, on continue de charger tous les dépassements de seuils quand on ouvre le contrôle. On pourrait faire une modif d'API au niveau des permissions pour faire des appels à chaque fois comme dans l'historique salarié