### PR TITLE
fix(history): week label 'D - D + 7' -> 'D - D + 6'

### DIFF
--- a/web/pwa/screens/History.js
+++ b/web/pwa/screens/History.js
@@ -105,7 +105,7 @@ const tabs = {
             -
           </Typography>
           <Typography className={missions ? "bold" : ""}>
-            {shortPrettyFormatDay(period + DAY * 7)}
+            {shortPrettyFormatDay(period + DAY * 6)}
           </Typography>
         </Box>
       );


### PR DESCRIPTION
https://trello.com/c/I8lB9IzK/1284-vue-semaine-historique-salari%C3%A9-les-semaines-doivent-aller-du-lundi-au-dimanche