### PR TITLE
fix(FA-AC_connect): remove iss param from callbackUrl

### DIFF
--- a/web/signup/AgentConnectCallback.js
+++ b/web/signup/AgentConnectCallback.js
@@ -59,7 +59,8 @@ export function AgentConnectCallback() {
     const errorDescription = queryString.get("error_description");
     const newQS = removeParamsFromQueryString(window.location.search, [
       "code",
-      "state"
+      "state",
+      "iss"
     ]);
     const callBackUrl =
       window.location.origin +

--- a/web/signup/FranceConnectCallback.js
+++ b/web/signup/FranceConnectCallback.js
@@ -70,7 +70,8 @@ export function FranceConnectCallback() {
     const state = queryString.get("state");
     const newQS = removeParamsFromQueryString(window.location.search, [
       "code",
-      "state"
+      "state",
+      "iss"
     ]);
     const callBackUrl =
       window.location.origin +


### PR DESCRIPTION
Context :
- Library update 'panva' from A/F-connect add a query param 'iss' to the Service Provider (FS in fr) callbackUrl like Mobilic.
- This callbackUrl was used to make a POST request to /token path of A/F-connect, which led to error when login from controller users ;
- Remove 'iss' query param from France_connect callbackUrl for future update (send issuer in redirect uri is a standard) ;

Solution :
- Remove 'iss' query param from callbackUrl fixed the problem ;

https://trello.com/c/OI16HiaJ/1449-probl%C3%A8me-connexion-controleur