### PR TITLE
fix(regulations): open correct info drawer for daily break regulatory alerts in history

### DIFF
--- a/common/utils/regulation/alertTypes.js
+++ b/common/utils/regulation/alertTypes.js
@@ -48,6 +48,6 @@ export const ALERT_TYPE_PROPS_SIMPLER = {
     rule: REGULATION_RULES.weeklyWork
   },
   [ALERT_TYPES.enoughBreak]: {
-    rule: REGULATION_RULES.weeklyWork
+    rule: REGULATION_RULES.dailyRest
   }
 };


### PR DESCRIPTION
https://trello.com/c/seaKT921/2033-modifier-le-lien-vers-la-r%C3%A9glementation-du-temps-de-pause-accessible-depuis-lhistorique