### PR TITLE
fix(validations): deduplicate employees in validation filter

### DIFF
--- a/web/admin/store/reducers/validationsFilters.js
+++ b/web/admin/store/reducers/validationsFilters.js
@@ -8,17 +8,24 @@ export function updateValidationsFiltersReducer(state, payload) {
   };
 }
 
-export function computeUsersInValidationFilter(users, adminedTeams, usersWithoutTeam) {
-  const allUsers = adminedTeams.reduce(
-    (accumulator, currentTeam) =>
-      accumulator.concat(
-        currentTeam.users.map(user => ({
-          ...user,
-          teamId: currentTeam.id,
-          teamName: currentTeam.name
-        }))
-      ),
-    usersWithoutTeam || []
-  );
-  return allUsers;
+export function computeUsersInValidationFilter(allCompanyUsers, adminedTeams, usersWithoutTeam) {
+  return allCompanyUsers.reduce((accumulator, currentUser) => {
+    const foundTeam = adminedTeams.find(team =>
+      team.users?.some(u => u.id === currentUser.id)
+    );
+    if (foundTeam) {
+      accumulator.push({
+        ...currentUser,
+        teamId: foundTeam.id,
+        teamName: foundTeam.name
+      });
+    } else {
+      if (usersWithoutTeam.some(u => u.id === currentUser.id)) {
+        accumulator.push({
+          ...currentUser
+        });
+      }
+    }
+    return accumulator;
+  }, []);
 }


### PR DESCRIPTION
https://trello.com/c/mqcBZ3nu/2585-bug-l%C3%A9ger-doublons-de-salari%C3%A9s-affich%C3%A9s-dans-la-recherche-des-saisies-%C3%A0-valider

## Summary

- PR #831 introduced a regression: `computeUsersInValidationFilter` received a deduplicated `users` param but never used it, still concatenating `team.users` → duplicates remained
- Rewrites the function to iterate over `allCompanyUsers` (deduplicated by caller) instead of concatenating team members
- Aligns with `computeUsersInActivityFilter` pattern (same file, same logic)

