### PR TITLE
fix/mission-id-in-tags-activity-tab

### DIFF
--- a/web/admin/components/WorkTimeTable.js
+++ b/web/admin/components/WorkTimeTable.js
@@ -105,7 +105,7 @@ const formatStatus = (status, entry, openMission) => {
   if (!status || !entry || !openMission) {
     return null;
   }
-  const missionId = entry.id;
+  const missionId = Object.keys(entry.missionNames)[0]
 
   switch (status) {
     case MISSION_STATUS.ongoing:

--- a/web/admin/components/WorkTimeTable.js
+++ b/web/admin/components/WorkTimeTable.js
@@ -109,22 +109,22 @@ const formatStatus = (status, entry, openMission) => {
 
   switch (status) {
     case MISSION_STATUS.ongoing:
-      tag = <RunningTag text={MISSION_STATUS.ongoing} />;
+      tag = <RunningTag/>;
       break;
     case MISSION_STATUS.toValidateAdmin:
-      tag = <ToValidateTag text={MISSION_STATUS.toValidateAdmin} printIcon={false} />;
+      tag = <ToValidateTag printIcon={false} />;
       break;
     case MISSION_STATUS.waitingWorker:
-      tag = <WaitingTag text={MISSION_STATUS.waitingWorker} />;
+      tag = <WaitingTag/>;
       break;
     case MISSION_STATUS.validated:
-      tag = <ValidatedTag text={MISSION_STATUS.validated} />;
+      tag = <ValidatedTag/>;
       break;
     case MISSION_STATUS.allValidated:
-      tag = <AllValidatedTag text={MISSION_STATUS.allValidated} />;
+      tag = <AllValidatedTag/>;
       break;
     case MISSION_STATUS.deleted:
-      tag = <DeletedTag text={MISSION_STATUS.deleted} />;
+      tag = <DeletedTag/>;
       break;
   }
   return (

--- a/web/admin/drawers/Tags.js
+++ b/web/admin/drawers/Tags.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { fr } from "@codegouvfr/react-dsfr";
 import { makeStyles } from "@mui/styles";
 import { Tag } from "@codegouvfr/react-dsfr/Tag";
+import { MISSION_STATUS } from "../utils/missionsStatus";
 
 const tagsStyles = makeStyles((theme) => ({
   running: {
@@ -32,54 +33,54 @@ const tagsStyles = makeStyles((theme) => ({
   }
 }));
 
-export const RunningTag = ({text, style}) => {
+export const RunningTag = ({style}) => {
   const classes = tagsStyles();
   return <Tag className={classes.running + ' fr-tag--sm'} style={style}>
-    {text || "Mission en cours"}
+    {MISSION_STATUS.ongoing}
     </Tag>;
 };
 
-export const ToValidateTag = ({text, printIcon, style}) => {
+export const ToValidateTag = ({printIcon, style}) => {
   const classes = tagsStyles();
   return (
       <Tag iconId={printIcon ? "fr-icon-warning-line" : ''} className={classes.toValidate + ' fr-tag--sm'} style={style}>
-        {text || "Saisies à valider"}
+        {MISSION_STATUS.toValidateAdmin}
       </Tag>
   )
 };
 
-export const WaitingTag = ({text, style}) => {
+export const WaitingTag = ({style}) => {
   const classes = tagsStyles();
   return (
     <Tag className={classes.waiting + ' fr-tag--sm'} style={style}>
-      {text || "En attente de validation par le salarié"}
+      {MISSION_STATUS.waitingWorker}
     </Tag>
   );
 };
 
-export const ValidatedTag = ({text, style}) => {
+export const ValidatedTag = ({style}) => {
   const classes = tagsStyles();
   return (
     <Tag className={classes.validated + ' fr-tag--sm'} style={style}>
-      {text || "Validée"}
+      {MISSION_STATUS.validated}
       </Tag>
   );
 };
 
-export const AllValidatedTag = ({text, style}) => {
+export const AllValidatedTag = ({style}) => {
   const classes = tagsStyles();
   return (
     <Tag className={classes.allValidated + ' fr-tag--sm'} style={style}>
-      {text || "Validée"}
+      {MISSION_STATUS.allValidated}
       </Tag>
   );
 };
 
-export const DeletedTag = ({text, style}) => {
+export const DeletedTag = ({style}) => {
   const classes = tagsStyles();
   return (
     <Tag className={classes.deleted + ' fr-tag--sm'} style={style}>
-      {text || "Supprimé"}
+      {MISSION_STATUS.deleted}
     </Tag>
   )
 }

--- a/web/admin/drawers/Tags.js
+++ b/web/admin/drawers/Tags.js
@@ -86,7 +86,6 @@ export const DeletedTag = ({style}) => {
 }
 
 const baseTagPropTypes = {
-  text: PropTypes.string,
   style: PropTypes.object
 };
 


### PR DESCRIPTION
- The mission ID was not handled correctly when clicking the mission status tag, causing the drawer to open with an error because the mission data could not be retrieved.

- Standardized mission status labels between the drawer and the activity table.