### PR TITLE
fix(admin): open day drawer instead of mission drawer for validated days

### DIFF
--- a/web/admin/components/MissionStatusTagBtn.js
+++ b/web/admin/components/MissionStatusTagBtn.js
@@ -4,10 +4,10 @@ import { useMatomo } from "@datapunt/matomo-tracker-react";
 import { Link } from "../../common/LinkButton";
 import { OPEN_MISSION_DRAWER_IN_ACTIVITY_PANEL } from "common/utils/matomoTags";
 
-export const MissionStatusTagBtn = ({ children, openMission, missionId }) => {
+export const MissionStatusTagBtn = ({ children, openMission, openWorkDay, missionId }) => {
     const { trackEvent } = useMatomo();
 
-    if (openMission && !missionId) {
+    if ((!openMission && !openWorkDay) || (openMission && !missionId)) {
         return <span>{children}</span>;
     }
 
@@ -20,6 +20,8 @@ export const MissionStatusTagBtn = ({ children, openMission, missionId }) => {
                 if (openMission) {
                     trackEvent(OPEN_MISSION_DRAWER_IN_ACTIVITY_PANEL);
                     openMission(missionId);
+                } else if (openWorkDay) {
+                    openWorkDay();
                 }
             }}
         >

--- a/web/admin/components/MissionStatusTagBtn.js
+++ b/web/admin/components/MissionStatusTagBtn.js
@@ -33,5 +33,6 @@ export const MissionStatusTagBtn = ({ children, openMission, openWorkDay, missio
 MissionStatusTagBtn.propTypes = {
     children: PropTypes.node,
     openMission: PropTypes.func,
+    openWorkDay: PropTypes.func,
     missionId: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
 };

--- a/web/admin/components/WorkTimeTable.js
+++ b/web/admin/components/WorkTimeTable.js
@@ -99,7 +99,7 @@ const formatWeeklyInfractions = (_, entry) => {
   return <InfractionsNumber nbAlerts={entry.weeklyAlerts} />;
 };
 
-const formatStatus = (status, entry, openMission) => {
+const formatStatus = (status, entry, openMission, openWorkday) => {
   let tag = null;
 
   if (!status || !entry || !openMission) {
@@ -128,9 +128,17 @@ const formatStatus = (status, entry, openMission) => {
       break;
   }
   return (
-     <MissionStatusTagBtn missionId={missionId} openMission={openMission}>
+    <MissionStatusTagBtn
+      missionId={missionId}
+      openWorkDay={
+        status === MISSION_STATUS.allValidated
+          ? () => openWorkday(entry)
+          : null
+      }
+      openMission={status === MISSION_STATUS.allValidated ? null : openMission}
+    >
       {tag}
-     </MissionStatusTagBtn>
+    </MissionStatusTagBtn>
   );
 };
 
@@ -445,7 +453,7 @@ export function WorkTimeTable({
   const statusCol = {
     label: "Statut",
     name: "statusKey",
-    format: (statusKey, entry) => formatStatus(statusKey, entry, openMission),
+    format: (statusKey, entry) => formatStatus(statusKey, entry, openMission, openWorkday),
     align: "left",
     minWidth: 120
   };


### PR DESCRIPTION
https://trello.com/c/NTduc6h0

Correction faite suite à ce commentaire après recette:

> @redwanezafari1 juste un petit retour : lorsqu’on clique sur le tag “journée validée”, il faut arriver sur le drawer journée et non pas mission. En effet, lorsqu’il y a plusieurs missions dans la journée cela ouvre une seule mission sur les deux.
> 
> Pour le reste tout est bon :)