### PR TITLE
fix(admin): show work day entries when missions are outside the 31-day window

### DIFF
--- a/web/admin/components/WorkTimeTable.js
+++ b/web/admin/components/WorkTimeTable.js
@@ -338,7 +338,7 @@ const preFormatWorkTimeEntries = (
       return [buildAllValidatedEntry(wte)];
     }
 
-    return missionIds
+    const entries = missionIds
       .map((missionId) =>
         buildMissionEntry(
           wte,
@@ -350,6 +350,22 @@ const preFormatWorkTimeEntries = (
         )
       )
       .filter(Boolean);
+
+    if (entries.length === 0) {
+      return [{
+        ...wte,
+        rest: wte.rest || null,
+        service: wte.service || null,
+        totalWork: wte.totalWork || null,
+        regulationComputations: wte.regulationComputations || null,
+        id: wte.user.id + wte.periodStart.toString(),
+        workerName: formatPersonName(wte.user),
+        statusKey: null,
+        selectable: true
+      }];
+    }
+
+    return entries;
   });
 
 const onRowClick = (entry, trackEvent, openWorkday, openMission) => {


### PR DESCRIPTION
https://trello.com/c/mzrjAauQ/2609-bug-affichage-des-missions-dans-longlet-activit%C3%A9s-vue-gestionnaire