### PR TITLE
fix(admin): keep aggregated rows on week/month views in activity table

### DIFF
--- a/web/admin/components/WorkTimeTable.js
+++ b/web/admin/components/WorkTimeTable.js
@@ -314,9 +314,20 @@ const preFormatWorkTimeEntries = (
   workTimeEntries,
   missionsById,
   currentUserId,
-  openMission
-) =>
-  workTimeEntries.flatMap((wte) => {
+  openMission,
+  period
+) => {
+  // Mission-level rows only make sense for the day view; week/month entries are already aggregated per employee.
+  if (period !== "day") {
+    return workTimeEntries.map((wte) => ({
+      ...wte,
+      id: wte.user.id + wte.periodStart.toString(),
+      workerName: formatPersonName(wte.user),
+      selectable: true
+    }));
+  }
+
+  return workTimeEntries.flatMap((wte) => {
     const missionIds = Object.keys(wte.missionNames || {});
     const mostRecentMissionId = getMostRecentMissionId(
       wte,
@@ -367,6 +378,7 @@ const preFormatWorkTimeEntries = (
 
     return entries;
   });
+};
 
 const onRowClick = (entry, trackEvent, openWorkday, openMission) => {
   if (!entry.day || trackEvent === null || openWorkday === null || openMission === null) {
@@ -524,7 +536,8 @@ export function WorkTimeTable({
     workTimeEntries,
     missionsById,
     adminStore.userId,
-    openMission
+    openMission,
+    period
   );
 
   return (


### PR DESCRIPTION
https://trello.com/c/b3aRuJ65/2615-vues-semaine-et-mois-le-cumul-ne-se-fait-plus