### PR TITLE
fix(front): adjust travel activity labels for accompaniment mode

### DIFF
--- a/common/components/VerticalTimeline.js
+++ b/common/components/VerticalTimeline.js
@@ -4,7 +4,10 @@ import { HOUR } from "../utils/time";
 import Typography from "@mui/material/Typography";
 import Box from "@mui/material/Box";
 import { makeStyles } from "@mui/styles";
-import { ACTIVITIES } from "../utils/activities";
+import {
+  ACTIVITIES,
+  getActivityLabelDependingOnMissionType
+} from "../utils/activities";
 
 const ORDERED_SCALES_IN_HOURS = [0.5, 1, 2, 3, 4, 6, 12, 24];
 
@@ -51,7 +54,8 @@ export function VerticalTimeline({
   heightTarget = 300,
   maxBarWidth = 40,
   idealNumberOfSteps = 5,
-  datetimeFormatter
+  datetimeFormatter,
+  isTeamMission = false
 }) {
   const classes = useStyles();
 
@@ -205,7 +209,7 @@ export function VerticalTimeline({
               noWrap
               variant="caption"
             >
-              {ACTIVITIES[type].label}
+              {getActivityLabelDependingOnMissionType(type, isTeamMission)}
             </Typography>
           </Box>
         ))}

--- a/common/utils/activities.js
+++ b/common/utils/activities.js
@@ -15,7 +15,7 @@ import { fr } from "@codegouvfr/react-dsfr";
 export const SWITCH_ACTIVITIES = {
   drive: {
     name: "drive",
-    label: "Déplacement",
+    label: "Travail",
     renderIcon: props => <TruckIcon {...props} />,
     color: fr.colors.decisions.artwork.major.greenArchipel.default,
     canBeFirst: true
@@ -373,4 +373,15 @@ export function computeDurationAndTime(activities, fromTime, untilTime) {
       duration: endTimeOrNow - startTime
     };
   });
+}
+
+export function getActivityLabelDependingOnMissionType(
+  type,
+  isTeamMission = false
+) {
+  if (!ACTIVITIES[type]) return "";
+  if (isTeamMission && type === ACTIVITIES.drive.name) {
+    return "Conduite";
+  }
+  return ACTIVITIES[type].label;
 }

--- a/common/utils/mission.js
+++ b/common/utils/mission.js
@@ -67,10 +67,22 @@ export function linkMissionsWithRelations(missions, relationMap) {
   return values(augmentedMissions);
 }
 
+export function computeIsTeamMission(activities = []) {
+  return (
+    new Set(
+      activities
+        .map(a => a.userId || a.user?.id)
+        .filter(id => id !== undefined && id !== null)
+    ).size > 1
+  );
+}
+
 export function augmentMissionWithProperties(mission, userId, companies = []) {
   const company =
     mission.company || companies.find(c => c.id === mission.companyId);
   const activities = mission.allActivities.filter(a => a.userId === userId);
+  const isTeamMission = computeIsTeamMission(mission.allActivities);
+
   return {
     ...mission,
     company,
@@ -90,6 +102,7 @@ export function augmentMissionWithProperties(mission, userId, companies = []) {
     ended:
       mission.isDeleted ||
       (mission.ended && activities.every(a => !!a.endTime)),
+    isTeamMission,
     submittedBySomeoneElse:
       mission.submitter && mission.submitter.id !== userId,
     lastActivityStartTime: activities[activities.length - 1]?.startTime
@@ -116,6 +129,7 @@ export function computeMissionStats(m, users) {
     activitiesWithUserId.map(a => a.user),
     u => u.id
   );
+  const isTeamMission = computeIsTeamMission(activitiesWithUserId);
   const validatorIds = m.validations.map(v => v.userId);
   const adminValidatedForMemberIds = m.validations
     .filter(v => v.isAdmin)
@@ -205,6 +219,7 @@ export function computeMissionStats(m, users) {
     endTime,
     endTimeOrNow: endTime || now1,
     isComplete,
+    isTeamMission,
     validatedByAllMembers,
     validatedByAdminForAllMembers,
     userStats,

--- a/web/admin/components/ActivitiesCard.js
+++ b/web/admin/components/ActivitiesCard.js
@@ -6,7 +6,7 @@ import { formatTimeOfDay, formatTimer, now } from "common/utils/time";
 import { ActivitiesPieChart } from "common/components/ActivitiesPieChart";
 import { AugmentedTable } from "./AugmentedTable";
 import { MissionInfoCard } from "./MissionInfoCard";
-import { ACTIVITIES } from "common/utils/activities";
+import { getActivityLabelDependingOnMissionType } from "common/utils/activities";
 import { Button } from "@codegouvfr/react-dsfr/Button";
 import { useActivitiesCardStyles } from "./styles/ActivitiesCardStyle";
 import SvgIcon from "@mui/material/SvgIcon";
@@ -31,7 +31,8 @@ export function ActivitiesCard({
   datetimeFormatter = formatTimeOfDay,
   titleProps = {},
   actionButtonLabel = "",
-  onActionButtonClick = null
+  onActionButtonClick = null,
+  isTeamMission = false,
 }) {
   const classes = useActivitiesCardStyles();
   const ref = React.useRef();
@@ -47,7 +48,8 @@ export function ActivitiesCard({
     {
       label: "Activité",
       name: "type",
-      format: type => ACTIVITIES[type].label,
+      format: type =>
+        getActivityLabelDependingOnMissionType(type, isTeamMission),
       maxWidth: 185,
       minWidth: 150
     },
@@ -163,6 +165,7 @@ export function ActivitiesCard({
                 width={300}
                 activities={activities}
                 datetimeFormatter={datetimeFormatter}
+                isTeamMission={isTeamMission}
               />
             </Grid>,
             <Grid

--- a/web/admin/components/MissionDetails/MissionDetails.js
+++ b/web/admin/components/MissionDetails/MissionDetails.js
@@ -407,7 +407,8 @@ export function MissionDetails({
                               nullableEndTime: false,
                               defaultTime: mission.startTime || day,
                               forcedUser: e.user,
-                              displayWarningMessage: false
+                              displayWarningMessage: false,
+                              isTeamMission: mission.isTeamMission
                             })
                         : null
                     }
@@ -446,7 +447,8 @@ export function MissionDetails({
                                 });
                                 await refreshData();
                                 handleClose();
-                              }
+                              },
+                              isTeamMission: mission.isTeamMission
                             })
                         : null
                     }

--- a/web/admin/components/MissionEmployeeCard.js
+++ b/web/admin/components/MissionEmployeeCard.js
@@ -293,6 +293,7 @@ export function MissionEmployeeCard({
                   onActionButtonClick: overrideValidation,
                   actionButtonLabel: "J'ai été absent : modifier les saisies"
                 })}
+              isTeamMission={mission.isTeamMission}
             />
           </Grid>
           {showExpenditures && (

--- a/web/landing/partners.js
+++ b/web/landing/partners.js
@@ -125,8 +125,6 @@ export function Partners() {
     return shuffle(partnersSrcs.keys().filter(src => src.startsWith('./')));
   }, []);
 
-  console.log('[DEBUG LOG] shuffledPartners', shuffledPartners);
-
   React.useEffect(() => {
     if (showAllPartners) {
       setPartnersToShow(shuffledPartners);

--- a/web/pwa/components/ActivityList.js
+++ b/web/pwa/components/ActivityList.js
@@ -8,7 +8,8 @@ import {
   ACTIVITIES_OPERATIONS,
   addBreaksToActivityList,
   computeDurationAndTime,
-  filterActivitiesOverlappingPeriod
+  filterActivitiesOverlappingPeriod,
+  getActivityLabelDependingOnMissionType
 } from "common/utils/activities";
 import {
   formatLongTimer,
@@ -67,6 +68,12 @@ function ActivityItem({
   const isLongBreak =
     isBreak && activity.duration && activity.duration >= LONG_BREAK_DURATION;
 
+  const isTeamMode = teamChanges && Object.keys(teamChanges).length > 0;
+  const activityLabel = getActivityLabelDependingOnMissionType(
+    activity.type,
+    isTeamMode
+  );
+
   return (
     <ListItem disableGutters>
       <ListItemAvatar>
@@ -80,7 +87,7 @@ function ActivityItem({
           <Typography className={isLongBreak ? classes.longBreak : ""}>
             {isLongBreak
               ? "Repos journalier"
-              : `${ACTIVITIES[activity.type].label}${
+              : `${activityLabel}${
                   activity.isMissionDeleted ? " (activité supprimée)" : ""
                 }`}
           </Typography>
@@ -155,7 +162,8 @@ function ActivityItem({
                 cancellable: true,
                 teamChanges,
                 allowTeamMode,
-                nullableEndTime: nullableEndTimeInEditActivity
+                nullableEndTime: nullableEndTimeInEditActivity,
+                isTeamMission: isTeamMode
               })
             }
           >

--- a/web/pwa/components/MissionDetails.js
+++ b/web/pwa/components/MissionDetails.js
@@ -276,7 +276,8 @@ export function MissionDetails({
                   allowSupportActivity,
                   allowOtherTask,
                   otherTaskLabel,
-                  defaultTime: lastActivityTime || defaultTime
+                  defaultTime: lastActivityTime || defaultTime,
+                  isTeamMission: mission.isTeamMission
                 })
             : null
         }

--- a/web/pwa/modals/ActivityRevision.js
+++ b/web/pwa/modals/ActivityRevision.js
@@ -5,7 +5,8 @@ import TextField from "common/utils/TextField";
 import {
   ACTIVITIES,
   ACTIVITIES_OPERATIONS,
-  convertNewActivityIntoActivityOperations
+  convertNewActivityIntoActivityOperations,
+  getActivityLabelDependingOnMissionType
 } from "common/utils/activities";
 import uniq from "lodash/uniq";
 import min from "lodash/min";
@@ -52,7 +53,8 @@ export default function ActivityRevisionOrCreationModal({
   defaultTime = null,
   forcedUser = null,
   displayWarningMessage = true,
-  handleCancelMission = null
+  handleCancelMission = null,
+  isTeamMission = false
 }) {
   const store = useStoreSyncedWithLocalStorage();
   const modals = useModals();
@@ -419,7 +421,11 @@ export default function ActivityRevisionOrCreationModal({
               {filteredActivities().map(activityName => {
                 const activity = ACTIVITIES[activityName];
                 const isDisabled = activityName === ACTIVITIES.support.name;
-                const label = `${activity.label}${
+                const activityLabel = getActivityLabelDependingOnMissionType(
+                  activityName,
+                  isTeamMission
+                );
+                const label = `${activityLabel}${
                   activityName === ACTIVITIES.work.name && otherTaskLabel
                     ? " - " + otherTaskLabel
                     : ""


### PR DESCRIPTION
* rename “Déplacement” to “Conduite” when the employee is the driver
* keep “Accompagnement” when the employee is not driving
* rename “Déplacement” to “Travail” when accompaniment mode is disabled
* apply the label changes to retrospective activity entry
* handle ongoing and retrospectively added missions for employees and managers

-> https://trello.com/c/wO73tfM9