### PR TITLE
change time format for each activity line employe view

### DIFF
--- a/common/utils/time.js
+++ b/common/utils/time.js
@@ -79,6 +79,16 @@ export function formatLongTimer(timerDuration) {
   } ${pluralize(timerDurationInMinutes % 60, "minute")}`;
 }
 
+export function formatShortTimer(timerDuration) {
+  if (!timerDuration && timerDuration !== 0) return null;
+  const minutes = (timerDuration / 60) >> 0;
+  const hours = (minutes / 60) >> 0;
+  const remainingMinutes = minutes % 60;
+  if (hours > 0 && remainingMinutes > 0) return `${hours} h ${remainingMinutes} min`;
+  if (hours > 0) return `${hours} h`;
+  return `${remainingMinutes} min`;
+}
+
 export function formatWarningDurationTime(timerDurationInSeconds) {
   if (!timerDurationInSeconds && timerDurationInSeconds !== 0) return null;
   const timerDurationInMinutes = (timerDurationInSeconds / 60) >> 0;

--- a/common/utils/time.js
+++ b/common/utils/time.js
@@ -81,8 +81,8 @@ export function formatLongTimer(timerDuration) {
 
 export function formatShortTimer(timerDuration) {
   if (!timerDuration && timerDuration !== 0) return null;
-  const minutes = (timerDuration / 60) >> 0;
-  const hours = (minutes / 60) >> 0;
+  const minutes = Math.trunc(timerDuration / 60);
+  const hours = Math.trunc(minutes / 60);
   const remainingMinutes = minutes % 60;
   if (hours > 0 && remainingMinutes > 0) return `${hours} h ${remainingMinutes} min`;
   if (hours > 0) return `${hours} h`;

--- a/web/pwa/components/ActivityList.js
+++ b/web/pwa/components/ActivityList.js
@@ -13,7 +13,7 @@ import {
   getActivityLabelDependingOnMissionType
 } from "common/utils/activities";
 import {
-  formatLongTimer,
+  formatShortTimer,
   formatTimeOfDay,
   LONG_BREAK_DURATION,
   now,
@@ -50,6 +50,9 @@ const useStyles = makeStyles(theme => ({
   },
   editButton: {
     color: fr.colors.decisions.text.actionHigh.blueFrance.default
+  },
+  activityItem: {
+    paddingRight: 100
   }
 }));
 
@@ -78,7 +81,7 @@ function ActivityItem({
   );
 
   return (
-    <ListItem disableGutters>
+    <ListItem disableGutters className={editActivityEvent ? classes.activityItem : ""}>
       <ListItemAvatar>
         <Avatar className={classes.avatar}>
           {ACTIVITIES[activity.type].renderIcon()}
@@ -110,7 +113,7 @@ function ActivityItem({
                 activity.displayedEndTime
                   ? `${datetimeFormatter(
                       activity.displayedEndTime
-                    )} - ${formatLongTimer(activity.duration)}`
+                    )} - ${formatShortTimer(activity.duration)}`
                   : "En cours"
               }`}
             </Typography>
@@ -120,7 +123,7 @@ function ActivityItem({
                   activity.operation.endTime
                     ? `${datetimeFormatter(
                         activity.operation.endTime
-                      )} - ${formatLongTimer(
+                      )} - ${formatShortTimer(
                         activity.operation.endTime -
                           activity.operation.startTime
                       )}`


### PR DESCRIPTION
Carte Trello : https://trello.com/c/aQVd5XbS/2219-58-etq-salari%C3%A9-je-veux-pouvoir-modifier-ma-mission-en-cours-%C3%A0-laide-dun-bouton-modifier-et-non-plus-un-crayon?filter=member%3Ajimmychevallier4

Demande de changement du format d'affichage de la durée d'une activité côté salarié, on veut afficher "3 h 30 min" au lieu de "3 heures 30 minutes" pour éviter la superposition avec le bouton modifier. Double sécurité en ajoutant un retour à la ligne dans le cas ou la résolution du mobile ne permette pas d'afficher l'ensemble sur une seule ligne.