### PR TITLE
fix(admin): preserve user and team selection after data refresh

### DIFF
--- a/web/admin/store/reducers/sync.js
+++ b/web/admin/store/reducers/sync.js
@@ -2,6 +2,12 @@ import flatMap from "lodash/flatMap";
 import { addWorkDaysReducer } from "./workDays";
 import { computeUsersAndTeamFilters } from "./team";
 
+export const preserveSelected = (newItems, existingItems) =>
+  newItems.map(item => {
+    const existing = existingItems?.find(e => e.id === item.id);
+    return existing ? { ...item, selected: existing.selected } : item;
+  });
+
 export function updateCompanyIdReducer(state, { companyId }) {
   return {
     ...state,
@@ -181,19 +187,14 @@ export function updateCompanyDetailsReducer(
     missions: regularMissions,
     activitiesFilters: {
       ...state.activitiesFilters,
-      teams: usersAndTeamsFilters.activitiesFilters.teams,
-      users: usersAndTeamsFilters.activitiesFilters.users,
-      minDate
+      teams: preserveSelected(usersAndTeamsFilters.activitiesFilters.teams, state.activitiesFilters.teams),
+      users: preserveSelected(usersAndTeamsFilters.activitiesFilters.users, state.activitiesFilters.users),
+      minDate,
     },
     validationsFilters: {
       ...state.validationsFilters,
-      teams: usersAndTeamsFilters.validationsFilters.teams,
-      users: usersAndTeamsFilters.validationsFilters.users.map(user => {
-        const existingUser = state.validationsFilters.users?.find(
-          u => u.id === user.id
-        );
-        return existingUser ? { ...user, selected: existingUser.selected } : user;
-    })
+      teams: preserveSelected(usersAndTeamsFilters.validationsFilters.teams, state.validationsFilters.teams),
+      users: preserveSelected(usersAndTeamsFilters.validationsFilters.users, state.validationsFilters.users),
     },
     exportFilters: {
       ...state.exportFilters,

--- a/web/admin/store/reducers/users.js
+++ b/web/admin/store/reducers/users.js
@@ -25,8 +25,8 @@ export function addUsersReducer(state, { companiesPayload }) {
     },
     validationsFilters: {
       ...state.validationsFilters,
-      teams: usersAndTeamsFilters.validationsFilters.teams,
-      users: usersAndTeamsFilters.validationsFilters.users
+      teams: preserveSelected(usersAndTeamsFilters.validationsFilters.teams, state.validationsFilters.teams),
+      users: preserveSelected(usersAndTeamsFilters.validationsFilters.users, state.validationsFilters.users)
     },
     exportFilters: {
       ...state.exportFilters,

--- a/web/admin/store/reducers/users.js
+++ b/web/admin/store/reducers/users.js
@@ -1,6 +1,7 @@
 import flatMap from "lodash/flatMap";
 import uniqBy from "lodash/uniqBy";
 import { computeUsersAndTeamFilters } from "./team";
+import { preserveSelected } from "./sync";
 
 export function addUsersReducer(state, { companiesPayload }) {
   const users = flatMap(
@@ -19,8 +20,8 @@ export function addUsersReducer(state, { companiesPayload }) {
     users: newUsers,
     activitiesFilters: {
       ...state.activitiesFilters,
-      teams: usersAndTeamsFilters.activitiesFilters.teams,
-      users: usersAndTeamsFilters.activitiesFilters.users
+      teams: preserveSelected(usersAndTeamsFilters.activitiesFilters.teams, state.activitiesFilters.teams),
+      users: preserveSelected(usersAndTeamsFilters.activitiesFilters.users, state.activitiesFilters.users)
     },
     validationsFilters: {
       ...state.validationsFilters,


### PR DESCRIPTION
Extracted preserveSelected helper in sync.js to avoid repetition when restoring selected state on activitiesFilters and validationsFilters.

Applied same logic in addUsersReducer to prevent losing the employee filter selection after adding a holiday or refreshing work days.



https://trello.com/c/o59XSMvB