### PR TITLE
fix(sentry): capture InvalidRefreshToken errors again

### DIFF
--- a/common/utils/sentry.js
+++ b/common/utils/sentry.js
@@ -5,8 +5,7 @@ const ERROR_NAMES_TO_FILTER_OUT = [
   "NetworkError",
   "WrongStatusError",
   "AbortError",
-  "TimeoutError",
-  "InvalidRefreshToken"
+  "TimeoutError"
 ];
 
 const ERROR_MESSAGES_TO_FILTER_OUT = [


### PR DESCRIPTION
https://trello.com/c/iNB3yLD6/2350-investigation-eviter-les-retry-et-revoir-le-refresh-token

PR back : https://github.com/MTES-MCT/mobilic-api/pull/757